### PR TITLE
Add a robotframework test for news item migration. Factor out a new noin...

### DIFF
--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -13,8 +13,7 @@ from plone.testing import z2
 from zope.configuration import xmlconfig
 
 
-class PloneAppContenttypes(PloneSandboxLayer):
-
+class PloneAppContenttypesNoInstall(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
@@ -26,7 +25,6 @@ class PloneAppContenttypes(PloneSandboxLayer):
         )
 
     def setUpPloneSite(self, portal):
-        applyProfile(portal, 'plone.app.contenttypes:default')
         portal.acl_users.userFolderAddUser('admin',
                                            'secret',
                                            ['Manager'],
@@ -34,11 +32,26 @@ class PloneAppContenttypes(PloneSandboxLayer):
         login(portal, 'admin')
         portal.portal_workflow.setDefaultChain("simple_publication_workflow")
         setRoles(portal, TEST_USER_ID, ['Manager'])
+
+PLONE_APP_CONTENTTYPES_NO_INSTALL_FIXTURE = PloneAppContenttypesNoInstall()
+PLONE_APP_CONTENTTYPES_NO_INSTALL_ROBOT_TESTING = FunctionalTesting(
+    bases=(PLONE_APP_CONTENTTYPES_NO_INSTALL_FIXTURE, z2.ZSERVER_FIXTURE),
+    name="PloneAppContenttypesNoInstall:Robot"
+)
+
+
+class PloneAppContenttypes(PloneSandboxLayer):
+
+    defaultBases = (PLONE_APP_CONTENTTYPES_NO_INSTALL_FIXTURE,)
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, 'plone.app.contenttypes:default')
         portal.invokeFactory(
             "Folder",
             id="robot-test-folder",
             title=u"Test Folder"
         )
+
 
 PLONE_APP_CONTENTTYPES_FIXTURE = PloneAppContenttypes()
 PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING = IntegrationTesting(

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -109,9 +109,11 @@ a news item
   fill in metadata
   Click Button  Save
   Wait until page contains  Item created
-  # ----------------------------------------------------------------------------
-  # Collection
-  # ----------------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------------
+# Collection
+# ----------------------------------------------------------------------------
 
 the collection should contain
   [Arguments]  ${title}
@@ -127,9 +129,8 @@ fill in metadata
   Click Link  Categorization
   Input text  name=form.widgets.IDublinCore.subjects  testcreated\nrobot
   Click Link  Dates
-  ${currentyear}=  Get Time  year
-  fill date field  form.widgets.IDublinCore.effective  2009  January  1
-  fill date field  form.widgets.IDublinCore.expires  2022  December  12
+  fill date field  form.widgets.IDublinCore.effective  2009  February  14
+  fill date field  form.widgets.IDublinCore.expires  2022  November  19
   Click Link  Ownership
   Input text  name=form.widgets.IDublinCore.creators  another_creator
   Input text  name=form.widgets.IDublinCore.contributors  contributor1\ncontributor2
@@ -146,3 +147,35 @@ fill date field
   Select from list  id=calmonth  ${month}
   Select from list  id=calyear  ${year}
   Click Link  xpath=//div[@class='calweek']//a[contains(text(), "${day}")]
+
+a ATNewsItem
+  [Arguments]  ${title}
+  [Documentation]  Create an Archetype based news item
+  Go to  ${PLONE_URL}/createObject?type_name=News+Item
+  Wait until page contains  Add News Item
+  Input text  name=title  ${title}
+  Choose File  name=image_file  ${PATH_TO_TEST_FILES}/image.png
+  Input text  name=imageCaption  ${title}'s caption
+  fill in metadata for an AT content
+  Click Button  Save
+
+
+fill in metadata for an AT content
+  Click Link  Categorization
+  Input text  name=subject_keywords:lines  testcreated\nrobot
+  Click Link  Dates
+  fill AT date field  effectiveDate  2009  January  1
+  fill AT date field  expirationDate  2018  December  12
+  Click Link  Creators
+  Input text  name=creators:lines  another_creator
+  Input text  name=contributors:lines  contributor1\ncontributor2
+  Input text  name=rights  Copyright\nstatement\nhere
+  Click Link  Settings
+  Select Checkbox  name=allowDiscussion:boolean
+  Select Checkbox  name=excludeFromNav:boolean
+
+fill AT date field
+  [Arguments]  ${fieldid}  ${year}=2012  ${month}=January  ${day}=10
+  Select from List  name=${fieldid}_year  ${year}
+  Select from List  name=${fieldid}_month  ${month}
+  Select from List  name=${fieldid}_day  ${day}

--- a/plone/app/contenttypes/tests/robot/migration/test_migrate_news_item.robot
+++ b/plone/app/contenttypes/tests/robot/migration/test_migrate_news_item.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Suite Setup     Suite Setup
+Suite Teardown  Suite Teardown
+Variables       plone/app/testing/interfaces.py
+Variables       plone/app/contenttypes/tests/robot/variables.py
+Library         Selenium2Library  timeout=${SELENIUM_TIMEOUT}  implicit_wait=${SELENIUM_IMPLICIT_WAIT}
+Resource        plone/app/contenttypes/tests/robot/keywords.txt
+Variables       ../variables.py
+
+*** Test Cases ***
+Scenario: Test Migration
+  Given a ATNewsItem  Test news item
+  When I install plone.app.contenttypes
+   And I migrate all content
+  Then I can edit my news item
+
+*** Keywords ***
+I go to
+  [Arguments]  ${location}
+  Go to  ${location}
+
+I install plone.app.contenttypes
+  Go to  ${PLONE_URL}/prefs_install_products_form
+  Select Checkbox  id=plone.app.contenttypes
+  Click Button  Activate
+  Sleep  10
+
+I migrate all content
+  Go to  ${PLONE_URL}/migrate_from_atct
+
+I can edit my news item
+  Go to  ${PLONE_URL}/test-news-item/edit
+  Input text  name=form.widgets.IDublinCore.title  A new title
+  fill in metadata
+  Click Button  Save
+  Wait until page contains  A new title

--- a/plone/app/contenttypes/tests/robot/variables.py
+++ b/plone/app/contenttypes/tests/robot/variables.py
@@ -19,3 +19,4 @@ REMOTE_URL = os.environ.get('REMOTE_URL', "")
 DESIRED_CAPABILITIES = os.environ.get('DESIRED_CAPABILITIES', "")
 
 TEST_FOLDER = os.environ.get('TEST_FOLDER', "%s/robot-test-folder" % PLONE_URL)
+PATH_TO_TEST_FILES = os.path.join(os.path.dirname(__file__), '..')

--- a/plone/app/contenttypes/tests/test_robot.py
+++ b/plone/app/contenttypes/tests/test_robot.py
@@ -5,9 +5,9 @@ import unittest
 from plone.testing import layered
 
 import robotsuite
-
 from plone.app.contenttypes.testing import (
-    PLONE_APP_CONTENTTYPES_ROBOT_TESTING
+    PLONE_APP_CONTENTTYPES_ROBOT_TESTING,
+    PLONE_APP_CONTENTTYPES_NO_INSTALL_ROBOT_TESTING
 )
 
 
@@ -25,4 +25,10 @@ def test_suite():
             layered(robotsuite.RobotTestSuite(test),
                     layer=PLONE_APP_CONTENTTYPES_ROBOT_TESTING),
         ])
+    migration_testpath = os.path.join(
+        'robot', 'migration', 'test_migrate_news_item.robot')
+    suite.addTests([
+        layered(robotsuite.RobotTestSuite(migration_testpath),
+                layer=PLONE_APP_CONTENTTYPES_NO_INSTALL_ROBOT_TESTING),
+    ])
     return suite


### PR DESCRIPTION
...stall test fixture that doesn't install p.a.contenttypes in portal_quickinstaller.

I expected the test to break on edit of the news item after the migration, but it doesn't.
@pbauer did I miss something?

Also, I'm not sure this test was intended to go to master, but I cant' ask (or don't know how to) for a new branch in a pull request.
