### PR TITLE
remove dependency on plone.app.referenceablebehavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0rc1 (unreleased)
 -------------------
 
+- Remove dependency on plone.app.referenceablebehavior, as it depends on
+  Products.Archetypes which installs the uid_catalog.
+  [thet]
+
 - make collection syndicatable
   [vangheem]
 

--- a/plone/app/contenttypes/profiles/default/types/Folder.xml
+++ b/plone/app/contenttypes/profiles/default/types/Folder.xml
@@ -30,7 +30,6 @@
   <element
      value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
   <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
-  <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
   <element value="plone.app.relationfield.behavior.IRelatedItems"/>
   <element value="plone.app.dexterity.behaviors.nextprevious.INextPreviousToggle"/>
  </property>

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(name='plone.app.contenttypes',
           'plone.formwidget.querystring',
           'plone.namedfile [blobs]',
           'plone.app.versioningbehavior',
-          'plone.app.referenceablebehavior',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
This pull-req removes the dependency on plone.app.referenceablebehavior, as it depends on Products.Archetypes which itself installs the uid_catalog.
With the plone.app.referenceablebehavior dependency in place, installing Plone 5 site will lead to a error, where plone.app.referenceablebehavior tries to get the uid_catalog.

For interoperability with Archetypes in a < Plone 5 environment, i suggest to either:
- document how to add the referenceablebehavior to Folder and any other content types, which need it,
- or to use a setup.py extra depencency section and do a setuphandler step, which adds this behavior to any needed p.a.contenttypes based types.
