### PR TITLE
Require plone.app.event < 1.2.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.1b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Require plone.app.event < 1.2.1
+  (https://github.com/plone/plone.app.event/issues/151)
+  [khink]
 
 
 1.1b2 (2014-02-21)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='plone.app.contenttypes',
           'setuptools',
           'Products.CMFPlone',
           'plone.app.contentmenu',
-          'plone.app.event [dexterity]',
+          'plone.app.event [dexterity]<1.2.1',
           'plone.app.dexterity>=2.0.7',  # has a fix for INameFromFilename
           'plone.dexterity>=2.2.1',  # behaviors can provide primaryfields
           'plone.app.relationfield',


### PR DESCRIPTION
p.a.event 1.2.1 breaks Plone 4.3 compatibility. Pinning the version of p.a.event to something smaller than that fixes it.

https://github.com/plone/plone.app.event/issues/151
