### PR TITLE
Fix race condition between migrate_at_uuid and migrate_relatedItems

### DIFF
--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -172,12 +172,11 @@ class ReferenceMigrator(object):
                 relatedItemsOrder = [item.UID() for item in relatedItems]
                 obj._relatedItemsOrder = PersistentList(relatedItemsOrder)
 
-    def migrate_relatedItems(self):
+    def migrate_at_relatedItems(self):
         """ Store Archetype relations as target uids on the dexterity object
             for later restore. Backrelations are saved as well because all
             relation to deleted objects would be lost.
         """
-
         # Relations:
         relItems = self.old.getRelatedItems()
         relUids = [item.UID() for item in relItems]


### PR DESCRIPTION
For @pbauer 

migrate_relatedItems should be executed before migrate_at_uuid, because migrate_at_uuid should remove UID to prevent AT UID related events breaking unmigrated AT references

See discussion at https://github.com/plone/Products.contentmigration/commit/32b4639a7544d109304fee6e9327d682fc637cc5
