### PR TITLE
PLIP 20144: Folderish types

### DIFF
--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -13,8 +13,8 @@ from zope.interface import implementer
 
 
 @implementer(ICollection)
-class Collection(Item):
-    """Convinience Item subclass for ``Collection`` portal type
+class Collection(Container):
+    """Convinience subclass for ``Collection`` portal type
     """
     # BBB
 
@@ -58,8 +58,8 @@ class Collection(Item):
 
 
 @implementer(IDocument)
-class Document(Item):
-    """Convinience Item subclass for ``Document`` portal type
+class Document(Container):
+    """Convinience subclass for ``Document`` portal type
     """
 
 
@@ -82,18 +82,18 @@ class Image(Item):
 
 
 @implementer(ILink)
-class Link(Item):
+class Link(Container):
     """Convinience subclass for ``Link`` portal type
     """
 
 
 @implementer(INewsItem)
-class NewsItem(Item):
+class NewsItem(Container):
     """Convinience subclass for ``News Item`` portal type
     """
 
 
 @implementer(IEvent)
-class Event(Item):
+class Event(Container):
     """Convinience subclass for ``Event`` portal type
     """

--- a/plone/app/contenttypes/tests/oldtypes.py
+++ b/plone/app/contenttypes/tests/oldtypes.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
-from plone.dexterity.fti import DexterityFTI
-from plone.dexterity.content import Item
+from plone.app.contenttypes.interfaces import IDocument
 from plone.app.contenttypes.interfaces import IEvent
+from plone.dexterity.content import Item
+from plone.dexterity.fti import DexterityFTI
 from zope.interface import implementer
 
 
 @implementer(IEvent)
 class Event(Item):
     """Dummy subclass for old ``Event`` portal type
+    """
+
+
+@implementer(IDocument)
+class Document(Item):
+    """Dummy subclass for non-folderish ``Document`` portal type
     """
 
 

--- a/plone/app/contenttypes/tests/test_upgrade.py
+++ b/plone/app/contenttypes/tests/test_upgrade.py
@@ -12,6 +12,8 @@ from plone.app.contenttypes.testing import (
 )
 
 from plone.app.contenttypes.upgrades import update_fti
+from plone.app.contenttypes.upgrades import migrate_to_folderish_types
+from plone.app.contenttypes.content import Document
 
 
 class UpgradeTo1000IntegrationTest(unittest.TestCase):
@@ -131,3 +133,60 @@ class UpgradeTo1000IntegrationTest(unittest.TestCase):
             fti.model_file,
             'plone.app.contenttypes.schema:news_item.xml'
         )
+
+
+class UpgradeTo1103IntegrationTest(unittest.TestCase):
+    """Test the upgrade to folderish types
+    """
+
+    layer = PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.request['ACTUAL_URL'] = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+
+    def test_migrate_to_folderish_types(self):
+        fti = queryUtility(
+            IDexterityFTI,
+            name='Document'
+        )
+        fti.klass = "plone.app.contenttypes.tests.oldtypes.Document"
+
+        self.portal.invokeFactory(
+            'Folder',
+            'folder1'
+        )
+        folder1 = self.portal['folder1']
+        folder1.invokeFactory(
+            'Document',
+            'doc1'
+        )
+        folder1.invokeFactory(
+            'News Item',
+            'news1'
+        )
+        doc1 = folder1['doc1']
+        doc1.description = "A initially itemish Document"
+        news1 = folder1['news1']
+        self.assertEqual(doc1.meta_type, 'Dexterity Item')
+        self.assertEqual(news1.meta_type, 'Dexterity Container')
+        # We can't change the base_class of the document class in a test
+        # while keeping the class the same. So we fake this by changing the
+        # class of the instance and re-adding it to the folder.
+        folder1._delOb('doc1')
+        doc1.__class__ = Document
+        folder1._setOb('doc1', doc1)
+        # Setting the fti to the default is not really needed for the test
+        # but is closer to the real thing where obj.__class__ and fti.klass
+        # stay the same. Also this would allow us to use
+        # migrate_base_class_to_new_class(obj, migrate_to_folderish=True)
+        # in the upgrade-step.
+        fti.klass = "plone.app.contenttypes.content.Document"
+
+        migrate_to_folderish_types(self.portal.portal_setup)
+        self.assertEqual(doc1.meta_type, 'Dexterity Container')
+        view = doc1.restrictedTraverse('@@view')()
+        self.assertIn('A initially itemish Document', view)

--- a/plone/app/contenttypes/upgrades.zcml
+++ b/plone/app/contenttypes/upgrades.zcml
@@ -62,4 +62,13 @@
       handler=".upgrades.enable_shortname_behavior"
       />
 
+  <genericsetup:upgradeStep
+      source="1103"
+      destination="1104"
+      title="Migrate to folderish types"
+      description=""
+      profile="plone.app.contenttypes:default"
+      handler=".upgrades.migrate_to_folderish_types"
+      />
+
 </configure>


### PR DESCRIPTION
See https://dev.plone.org/ticket/20144
- make all types except File and Image folderish
- add a upgrade-step to migrate non-folderish to folderish
- test folderish documents with allowed_content_types
- test upgrade to folderish types
