### PR TITLE
moved test specific setup out of fixture setup

### DIFF
--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -43,9 +43,6 @@ class PloneAppContenttypes(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
-        mtr = portal.mimetypes_registry
-        mime_doc = mtr.lookup('application/msword')[0]
-        mime_doc.icon_path = 'custom.png'
 
         portal.acl_users.userFolderAddUser('admin',
                                            'secret',

--- a/plone/app/contenttypes/tests/test_file.py
+++ b/plone/app/contenttypes/tests/test_file.py
@@ -2,6 +2,7 @@
 import unittest2 as unittest
 
 import os.path
+import transaction
 
 from zope.interface import alsoProvides
 from zope.component import createObject
@@ -89,6 +90,7 @@ class FileFunctionalTest(unittest.TestCase):
         self.portal = self.layer['portal']
         self.request = self.layer['request']
         self.portal_url = self.portal.absolute_url()
+
         self.browser = Browser(app)
         self.browser.handleErrors = False
         self.browser.addHeader(
@@ -127,6 +129,11 @@ class FileFunctionalTest(unittest.TestCase):
         self.assertTrue('pdf.png' in self.browser.contents)
 
     def test_alternative_mime_icon_doc_for_file(self):
+        mtr = self.portal.mimetypes_registry
+        mime_doc = mtr.lookup('application/msword')[0]
+        mime_doc.icon_path = 'custom.png'
+        transaction.commit()
+
         self.browser.open(self.portal_url)
         self.browser.getLink('File').click()
 


### PR DESCRIPTION
See 58138b5eb7983dc4d27684eb442e0a4b1db32643

Usually I would apply this fix to master and then backport it to 1.1.x, but the tests are failing for master on both jenkins and travis, and locally I need to change a couple of pinnings to get buildout to finish without error.
