### PR TITLE
audio/video tag for file view

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- In the file view, render HTML5 ``<audio>`` or ``<video>`` tags for audio
+  respectively video file types. Ancient browsers, which do not support that,
+  just don't render these tags.
+  [thet]
+
 - Add ``event_listing`` to available view methods for the Folder and Collection
   types.
   [thet]

--- a/plone/app/contenttypes/browser/configure.zcml
+++ b/plone/app/contenttypes/browser/configure.zcml
@@ -117,6 +117,7 @@
     name="file_view"
     for="plone.app.contenttypes.interfaces.IFile"
     layer="plone.app.contenttypes.interfaces.IPloneAppContenttypesLayer"
+    class=".file.FileView"
     template="templates/file.pt"
     permission="zope2.View"
     menu="plone_displayviews"

--- a/plone/app/contenttypes/browser/file.py
+++ b/plone/app/contenttypes/browser/file.py
@@ -1,0 +1,18 @@
+from plone.app.contenttypes.browser.utils import Utils
+
+
+class FileView(Utils):
+
+    def __init__(self, context, request):
+        super(FileView, self).__init__(context, request)
+
+    def is_videotype(self):
+        ct = self.context.file.contentType
+        return 'video/' in ct
+
+    def is_audiotype(self):
+        ct = self.context.file.contentType
+        return 'audio/' in ct
+
+    def get_mimetype_icon(self):
+        return super(FileView, self).getMimeTypeIcon(self.context.file)

--- a/plone/app/contenttypes/browser/templates/file.pt
+++ b/plone/app/contenttypes/browser/templates/file.pt
@@ -11,10 +11,10 @@
     <metal:content-core fill-slot="content-core">
         <metal:block define-macro="content-core"
                      tal:define="content_type context/file/contentType|nothing;
-                                 v python:context.restrictedTraverse('contenttype_utils');">
+                                 download_url string:${context/absolute_url}/@@download/file/${context/file/filename}">
             <p>
-                <a tal:attributes="href string:${context/absolute_url}/@@download/file/${context/file/filename}">
-                    <img tal:attributes="src python: v.getMimeTypeIcon(context.file);
+                <a tal:attributes="href download_url">
+                    <img tal:attributes="src view/get_mimetype_icon;
                                          alt content_type;" border="0"  />
                     <tal:name tal:content="context/file/filename" >Filename</tal:name>
                 </a>
@@ -23,6 +23,14 @@
                                   kb python:size/1024">
                       &mdash; <span tal:replace="kb" /> KB</span>
             </p>
+
+            <video tal:condition="view/is_videotype" controls="controls">
+              <source tal:attributes="src download_url; type content_type"></source>
+            </video>
+
+            <audio tal:condition="view/is_audiotype" controls="controls">
+              <source tal:attributes="src download_url; type content_type"></source>
+            </audio>
 
             <div tal:condition="python: content_type.startswith('text')">
                 <h2 i18n:translate="heading_file_contents">File contents</h2>

--- a/plone/app/contenttypes/browser/utils.py
+++ b/plone/app/contenttypes/browser/utils.py
@@ -31,8 +31,11 @@ class Utils(BrowserView):
         )
         portal_url = pstate.portal_url()
         mtr = getToolByName(context, "mimetypes_registry")
-        mime = list(mtr.lookup(content_file.contentType))
-        mime.append(mtr.lookupExtension(content_file.filename))
+        mime = []
+        if content_file.contentType:
+            mime.append(mtr.lookup(content_file.contentType))
+        if content_file.filename:
+            mime.append(mtr.lookupExtension(content_file.filename))
         mime.append(mtr.lookup("application/octet-stream")[0])
         icon_paths = [m.icon_path for m in mime if hasattr(m, 'icon_path')]
         if icon_paths:

--- a/plone/app/contenttypes/tests/test_file.py
+++ b/plone/app/contenttypes/tests/test_file.py
@@ -23,6 +23,9 @@ from plone.app.contenttypes.testing import (
 from plone.app.testing import TEST_USER_ID, setRoles
 from plone.app.z3cform.interfaces import IPloneFormLayer
 
+from plone.namedfile.file import NamedFile
+from plone.app.contenttypes.interfaces import IPloneAppContenttypesLayer
+
 
 class FileIntegrationTest(unittest.TestCase):
 
@@ -78,6 +81,37 @@ class FileIntegrationTest(unittest.TestCase):
         self.assertEqual(view.request.response.status, 200)
         self.assertTrue('My File' in view())
         self.assertTrue('This is my file.' in view())
+
+    def test_view_no_video_audio_tag(self):
+        self.portal.invokeFactory('File', 'file')
+        file = self.portal['file']
+        file.file = NamedFile()
+        file.file.contentType = 'application/pdf'
+        alsoProvides(self.request, IPloneAppContenttypesLayer)
+        view = file.restrictedTraverse('@@file_view')
+        rendered = view()
+        self.assertTrue('</audio>' not in rendered)
+        self.assertTrue('</video>' not in rendered)
+
+    def test_view_video_tag(self):
+        self.portal.invokeFactory('File', 'file')
+        file = self.portal['file']
+        file.file = NamedFile()
+        file.file.contentType = 'audio/mp3'
+        alsoProvides(self.request, IPloneAppContenttypesLayer)
+        view = file.restrictedTraverse('@@file_view')
+        rendered = view()
+        self.assertTrue('</audio>' in rendered)
+
+    def test_view_audio_tag(self):
+        self.portal.invokeFactory('File', 'file')
+        file = self.portal['file']
+        file.file = NamedFile()
+        file.file.contentType = 'video/ogv'
+        alsoProvides(self.request, IPloneAppContenttypesLayer)
+        view = file.restrictedTraverse('@@file_view')
+        rendered = view()
+        self.assertTrue('</video>' in rendered)
 
 
 class FileFunctionalTest(unittest.TestCase):


### PR DESCRIPTION
In the file view, render HTML5 <audio> or <video> tags for audio respectively video file types. Ancient browsers, which do not support that, just don't render these tags.