### PR TITLE
Fix ``contentFilter`` for collections.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Fix ``contentFilter`` for collections.
+  [thet]
+
 - Cache the results of the collection and folder view on the request. The
   results might be called again by other packages to extract information on the
   result list.

--- a/plone/app/contenttypes/browser/collection.py
+++ b/plone/app/contenttypes/browser/collection.py
@@ -30,7 +30,9 @@ class CollectionView(FolderView):
                 sequence.
         """
         # Extra filter
-        kwargs.update(dict(getattr(self.request, 'contentFilter', {})))
+        contentFilter = self.request.get('contentFilter', {})
+        contentFilter.update(kwargs.get('contentFilter', {}))
+        kwargs.setdefault('custom_query', contentFilter)
         kwargs.setdefault('batch', True)
         kwargs.setdefault('b_size', self.b_size)
         kwargs.setdefault('b_start', self.b_start)

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -56,7 +56,7 @@ class FolderView(BrowserView):
                 sequence.
         """
         # Extra filter
-        kwargs.update(dict(getattr(self.request, 'contentFilter', {})))
+        kwargs.update(self.request.get('contentFilter', {}))
         kwargs.setdefault('portal_type', self.friendly_types)
         kwargs.setdefault('batch', True)
         kwargs.setdefault('b_size', self.b_size)


### PR DESCRIPTION
This allows the contentFilter dictionary on a request to narrow down listings