### PR TITLE
Don't use <figure> and <figcaption> html5

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.1b6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't use <figure> and <figcaption> html5 containers for Plone 4
+  compatibility. sunburst css selectors don't support figure yet in
+  for example newsitem styling.
+  [fredvd]
 
 
 1.1b5 (2015-05-29)

--- a/plone/app/contenttypes/browser/templates/image.pt
+++ b/plone/app/contenttypes/browser/templates/image.pt
@@ -9,19 +9,19 @@
 
 <metal:content-core fill-slot="content-core">
 <metal:block define-macro="content-core" tal:define="size context/image/getSize">
-  <figure class="image-product">
+  <div class="image-product">
     <a class="discreet"
         tal:attributes="href string:${context/@@plone_context_state/object_url}/image_view_fullscreen"
         tal:define="scale context/@@images;
                     img_tag python:scale.scale('image', scale='large').tag()"
         tal:on-error="string: Image cannot be displayed">
     <img tal:replace="structure img_tag" />
-    <figcaption class="discreet">
+    <div class="discreet">
       <strong class="sr-only" i18n:translate="label_click_to_view_full_image">Click to view full-size image&hellip;</strong>
       <span><tal:span i18n:translate="label_size">Size</tal:span>: <tal:span tal:replace="python:size/1024"> File size </tal:span>KB</span>
-    </figcaption>
+    </div>
     </a>
-  </figure>
+  </div>
 </metal:block>
 </metal:content-core>
 

--- a/plone/app/contenttypes/browser/templates/newsitem.pt
+++ b/plone/app/contenttypes/browser/templates/newsitem.pt
@@ -20,16 +20,16 @@
     tal:define="templateId template/getId;
                 scale_func context/@@images;
                 scaled_image python: getattr(context.aq_explicit, 'image', False) and scale_func.scale('image', scale='mini')">
-  <figure class="newsImageContainer" tal:condition="python: scaled_image">
+  <div class="newsImageContainer" tal:condition="python: scaled_image">
     <a tal:define="here_url context/@@plone_context_state/object_url;
                    large_image python: scale_func.scale('image', scale='large');"
         tal:attributes="href large_image/url">
       <img tal:replace="structure python: scaled_image.tag(css_class='newsImage')" />
-      <figcaption tal:condition="context/image_caption|nothing"
+      <div tal:condition="context/image_caption|nothing"
           tal:content="structure context/image_caption">
-      </figcaption>
+      </div>
     </a>
-  </figure>
+  </div>
 
   <div id="parent-fieldname-text"
       tal:condition="context/text"


### PR DESCRIPTION
No html5 containers for Plone 4 compatibility. plonetheme.sunburst css selectors don't support figure yet in for example newsitem styling.