### PR TITLE
FolderView results fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.2b5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- In ``FolderView`` based views, don't include the ``portal_types`` query, if
+  ``object_provides`` is set in the ``results`` method keyword arguments. Fixes
+  a case, where no Album Images were shown, when portal_state's
+  ``friendly_types`` didn't include the ``Image`` type.
+  [thet]
 
 
 1.2b4 (2015-08-22)

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -56,7 +56,8 @@ class FolderView(BrowserView):
         """
         # Extra filter
         kwargs.update(self.request.get('contentFilter', {}))
-        kwargs.setdefault('portal_type', self.friendly_types)
+        if 'object_provides' not in kwargs:  # object_provides is more specific
+            kwargs.setdefault('portal_type', self.friendly_types)
         kwargs.setdefault('batch', True)
         kwargs.setdefault('b_size', self.b_size)
         kwargs.setdefault('b_start', self.b_start)


### PR DESCRIPTION
 In ``FolderView`` based views, don't include the ``portal_types`` query, if ``object_provides`` is set in the ``results`` method keyword arguments. Fixes a case, where no Album Images were shown, when portal_state's ``friendly_types`` didn't include the ``Image`` type.
