### PR TITLE
remove code from deprecated getIcon, reuse metadata field getIcon

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ Fixes:
   [pbauer]
 
 - Fixed full_view when content is not IUUIDAware (like the portal).
+- remove code from deprecated getIcon, reuse metadata field getIcon 
+  for showing thumbs in content listings etc.:
+  https://github.com/plone/Products.CMFPlone/issues/1074
+  [fgrcon]
+  
+- Fix full_view when content is not IUUIDAware (like the portal).
   Fixes https://github.com/plone/Products.CMFPlone/issues/1109.
   [pbauer]
 

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -155,12 +155,6 @@ class FolderView(BrowserView):
             'value': value
         }
 
-    def has_image(self, obj):
-        if getattr(obj, 'getObject', False):
-            obj = obj.getObject()
-        img = getattr(aq_base(obj), 'image', None)
-        return True if img else False
-
     def is_event(self, obj):
         if getattr(obj, 'getObject', False):
             obj = obj.getObject()

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -31,23 +31,25 @@
                 item_type item/PortalType;
                 item_modified item/ModificationDate;
                 item_created item/CreationDate;
-                item_icon item/getIcon;
                 item_type_class python:'contenttype-' + view.normalizeString(item_type);
                 item_wf_state item/review_state;
                 item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
                 item_creator item/Creator;
-                item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;
-                item_has_image python:view.has_image(obj);
-                item_is_event python:view.is_event(obj)">
+                item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;                
+                item_is_event python:view.is_event(obj);
+                item_has_image python:item.getIcon">
               <metal:block define-slot="entry">
                 <article class="entry">
                   <header metal:define-macro="listitem" tal:attributes="class python:'vevent' if item_is_event else None">
-                    <span class="summary">
-                      <a tal:attributes="href item_link;
-                                         class string:$item_type_class $item_wf_state_class url;
-                                         title item_type"
-                          tal:content="item_title">
-                        Item Title
+                    <span class="summary" tal:attributes="title item_type">
+                      <a tal:attributes="href item_link">
+                        <img class="image-tile"
+                             tal:define="getIcon python:item.getURL()+'/@@images/image/tile'"
+                             tal:condition="item_has_image"                          
+                             tal:attributes="src  string:$getIcon">                                         
+                         <span tal:attributes="class string:$item_type_class $item_wf_state_class url;"                         	
+                               tal:content="item_title">
+                                 Item Title</span>
                       </a>
                     </span>
 

--- a/plone/app/contenttypes/browser/templates/listing_tabular.pt
+++ b/plone/app/contenttypes/browser/templates/listing_tabular.pt
@@ -55,6 +55,12 @@
                       <tal:block tal:replace="field_data/value" />
                     </td>
                     <td tal:condition="python:field == 'Title'">
+                      <img
+                         tal:define="getIcon python:item.getURL()+'/@@images/image/icon'"
+                         tal:condition="python:  item.getIcon"                          
+                         tal:attributes="href item/getURL;
+                                         src  string:$getIcon"
+                      />
                       <a href="#"
                           tal:attributes="href item_link;
                           class string:$item_wf_state_class $item_type_class;

--- a/plone/app/contenttypes/indexers.py
+++ b/plone/app/contenttypes/indexers.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from ZODB.POSException import ConflictError
 from logging import getLogger
+from plone.dexterity.interfaces import IDexterityContent
 from plone.app.contenttypes.interfaces import IDocument
 from plone.app.contenttypes.interfaces import IFile
 from plone.app.contenttypes.interfaces import IFolder
@@ -128,48 +129,16 @@ def getObjSize_file(obj):
     return obj.getObjSize(None, primary_field_info.value.size)
 
 
-@indexer(IFile)
-def getIcon_file(obj):
-    """icon of the given mimetype,
+@indexer(IDexterityContent)
+def getIcon(obj):
+    '''
+    geticon redefined in Plone > 5.0
+    see https://github.com/plone/Products.CMFPlone/issues/1151
+        https://github.com/plone/Products.CMFPlone/issues/1074
 
-    parts of this this code are borrowed from atct.
-    """
-    mtr = getToolByName(obj, 'mimetypes_registry', None)
-    if mtr is None:
-        return None
-
-    try:
-        primary_field_info = IPrimaryFieldInfo(obj, None)
-    except TypeError:
-        logger.warn(u'Lookup of PrimaryField failed for %s '
-                    u'If renaming or importing please reindex!' %
-                    obj.absolute_url())
-        return
-    if not primary_field_info.value:
-        # There is no file so we should show a generic icon
-        # TODO : find a better icon for generic
-        return 'png.png'
-        # return None
-
-    contenttype = None
-    if hasattr(primary_field_info.value, "contentType"):
-        contenttype = primary_field_info.value.contentType
-    if not contenttype:
-        contenttype = FALLBACK_CONTENTTYPE
-
-    mimetypeitem = None
-    try:
-        mimetypeitem = mtr.lookup(contenttype)
-    except Exception, msg:
-        logger.warn('mimetype lookup failed for %s. Error: %s' %
-                    (obj.absolute_url(), str(msg)))
-
-    if not mimetypeitem:
-        mimetypeitem = mtr.lookup(FALLBACK_CONTENTTYPE)
-
-    return mimetypeitem[0].icon_path
-
-
-@indexer(IImage)
-def getIcon_image(obj):
-    return getIcon_file(obj)
+    reuse of metadata field,
+    used for showing thumbs in content listings etc.
+    '''
+    if obj.image:
+        return True
+    return False

--- a/plone/app/contenttypes/indexers.zcml
+++ b/plone/app/contenttypes/indexers.zcml
@@ -13,7 +13,6 @@
   <adapter name="getRemoteUrl" factory=".indexers.getRemoteUrl" />
   <adapter name="getObjSize" factory=".indexers.getObjSize_image" />
   <adapter name="getObjSize" factory=".indexers.getObjSize_file" />
-  <adapter name="getIcon" factory=".indexers.getIcon_image" />
-  <adapter name="getIcon" factory=".indexers.getIcon_file" />
+  <adapter name="getIcon" factory=".indexers.getIcon" /> 
 
 </configure>

--- a/plone/app/contenttypes/tests/test_indexes.py
+++ b/plone/app/contenttypes/tests/test_indexes.py
@@ -280,33 +280,3 @@ class CatalogIntegrationTest(unittest.TestCase):
             self.portal.getObjSize(None, primary_field_info.value.size),
             brains[0].getObjSize,
         )
-
-    def test_geticon_image(self):
-        from .test_image import dummy_image
-
-        primary_field_info = IPrimaryFieldInfo(self.image)
-        primary_field_info.field.set(self.image, dummy_image())
-        self.image.reindexObject()
-
-        brains = self.catalog.searchResults(dict(
-            path="/plone/folder/image",
-        ))
-
-        self.assertEqual('image.png', brains[0].getIcon)
-
-    def test_geticon_file(self):
-        from plone.namedfile.file import NamedBlobFile
-
-        filename = os.path.join(os.path.dirname(__file__), u'file.pdf')
-        test_file = NamedBlobFile(data=open(filename, 'r').read(),
-                                  filename=filename)
-
-        primary_field_info = IPrimaryFieldInfo(self.file)
-        primary_field_info.field.set(self.file, test_file)
-        self.file.reindexObject()
-
-        brains = self.catalog.searchResults(dict(
-            path="/plone/folder/file",
-        ))
-
-        self.assertEqual('pdf.png', brains[0].getIcon)


### PR DESCRIPTION
  for showing thumbs in content listings etc.:
  https://github.com/plone/Products.CMFPlone/issues/1074
  [fgrcon]