### PR TITLE
IRichText indexing for all and html to plain transform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ New:
 
 Fixes:
 
+- Do a ``IRichText`` text indexing on all registered SearchableText indexers by
+  doing it as part of the base ``SearchableText`` function. Convert the text
+  from the source mimetype to ``text/plain``.
+  [thet]
+
 - Add ``getRawQuery`` method to Collection content type for backward compatibility with Archetypes API.
   Fixes (partially) https://github.com/plone/plone.app.contenttypes/issues/283.
   [hvelarde]
@@ -21,7 +26,7 @@ Fixes:
 
 Fixes:
 
-- Fixed custom migration from and to types with spaces in the type-name.
+- Fix custom migration from and to types with spaces in the type-name.
   [pbauer]
 
 - Fixed full_view when content is not IUUIDAware (like the portal).

--- a/plone/app/contenttypes/tests/test_indexes.py
+++ b/plone/app/contenttypes/tests/test_indexes.py
@@ -150,6 +150,24 @@ class CatalogIntegrationTest(unittest.TestCase):
             '/plone/folder/document'
         )
 
+    def test_html_stripped_searchable_text_index(self):
+        """Ensure, html tags are stripped out from the content and not indexed.
+        """
+        self.document.text = RichTextValue(
+            u'<p>Lorem <b>ipsum</b></p>',
+            mimeType='text/html',
+            outputMimeType='text/html'
+        )
+        self.document.reindexObject()
+        brains = self.catalog.searchResults(dict(
+            SearchableText=u'Lorem ipsum',
+        ))
+        self.assertEqual(len(brains), 1)
+        rid = brains[0].getRID()
+        index_data = self.catalog.getIndexDataForRID(rid)
+        self.assertEqual(index_data['SearchableText'].count('p'), 0)
+        self.assertEqual(index_data['SearchableText'].count('b'), 0)
+
     def test_file_fulltext_in_searchable_text_index_string(self):
         from plone.namedfile.file import NamedBlobFile
         data = ("Lorem ipsum. Köln <!-- ...oder München, das ist hier die "


### PR DESCRIPTION
Do a ``IRichText`` text indexing on all registered SearchableText indexers by doing it as part of the base ``SearchableText`` function. Convert the text from the source mimetype to ``text/plain``.