### PR TITLE
Add getRawQuery method to Collection content type for backward compatibility with Archetypes API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Add ``getRawQuery`` method to Collection content type for backward compatibility with Archetypes API.
+  Fixes (partially) https://github.com/plone/plone.app.contenttypes/issues/283.
+  [hvelarde]
 
 
 1.2.5 (2015-10-28)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -430,6 +430,8 @@ Differences to Products.ATContentTypes
 - There is no more field ``Location``. If you need georeferenceable consider using ``collective.geo.behaviour``
 - The link on the image of the newsitem triggers an overlay
 - The link-type now allows the of the variables ``${navigation_root_url}`` and ``${portal_url}`` to construct relative urls.
+- The ``getQuery()`` function now returns a list of dict instead of a list of CatalogContentListingObject;
+  use of ``getRawQuery()`` is deprecated.
 - The views for Folders and Collections changed their names and now share a common implementation (since version 1.2a8):
 
   - ``folder_listing_view`` (Folders) and ``collection_view`` (Collections) -> ``listing_view`` (Folders and Collections)
@@ -506,3 +508,4 @@ Contributors
 * Bogdan Girman <bogdan.girman@gmail.com>
 * Martin Opstad Reistadbakk <martin@blaastolen.com>
 * Florent Michon <fmichon@atreal.fr>
+* Héctor Velarde <hector.velarde@gmail.com>

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -9,6 +9,7 @@ from plone.app.contenttypes.interfaces import ILink
 from plone.app.contenttypes.interfaces import INewsItem
 from plone.dexterity.content import Container
 from plone.dexterity.content import Item
+from zope.deprecation import deprecation
 from zope.interface import implementer
 
 
@@ -37,7 +38,15 @@ class Collection(Item):
         self.query = query
 
     def getQuery(self):
+        """Return the query as a list of dict; note that this method
+        returns a list of CatalogContentListingObject in
+        Products.ATContentTypes.
+        """
         return self.query
+
+    @deprecation.deprecate('getRawQuery() is deprecated; use getQuery().')
+    def getRawQuery(self):
+        return self.getQuery()
 
     def setSort_on(self, sort_on):
         self.sort_on = sort_on

--- a/plone/app/contenttypes/tests/test_collection.py
+++ b/plone/app/contenttypes/tests/test_collection.py
@@ -75,6 +75,10 @@ class PloneAppCollectionClassTest(unittest.TestCase):
         self.collection.query = query
         self.assertEqual(self.collection.getQuery(), query)
 
+    def test_bbb_getRawQuery(self):
+        self.collection.query = query
+        self.assertEqual(self.collection.getRawQuery(), query)
+
     def test_bbb_setSort_on(self):
         self.collection.setSort_on('start')
         self.assertEqual(self.collection.sort_on, 'start')

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(name='plone.app.contenttypes',
           'plone.app.versioningbehavior',
           'plone.app.lockingbehavior',
           'pytz',
-          'plone.app.z3cform>=1.1.0.dev0'
+          'plone.app.z3cform>=1.1.0.dev0',
+          'zope.deprecation',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
closes #283 