### PR TITLE
Avoid AttributeError when trying to get the default_page of an item when migrating

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ New:
 
 Fixes:
 
+- Avoid AttributeError when trying to get the default_page of an item
+  when migrating
+  [frapell]
+
 - Used html5 doctype in image_view_fullscreen.  Now it can be parsed
   correctly by for example i18ndude.
   [maurits]

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -198,7 +198,7 @@ class ATCTFolderMigrator(CMFFolderMigrator):
         old_layout = self.old.getLayout() or getattr(self.old, 'layout', None)
         if old_layout in LISTING_VIEW_MAPPING.keys():
             default_page = self.old.getDefaultPage() or \
-                getattr(self.old, 'default_page')
+                getattr(self.old, 'default_page', None)
             self.new.setLayout(LISTING_VIEW_MAPPING[old_layout])
             if default_page:
                 # any defaultPage is switched of by setLayout


### PR DESCRIPTION
This is what I got when migrating a site from Plone 4.0.10

2015-11-18T11:39:48 ERROR ATCT.migration Failed migration for object /Plone/developer/presentations (Folder -> Folder)
Traceback (most recent call last):
  File "/opt/plone/eggs/Products.contentmigration-2.1.11-py2.7.egg/Products/contentmigration/basemigrator/walker.py", line 192, in migrate
    migrator.migrate()
  File "/opt/plone/eggs/Products.contentmigration-2.1.11-py2.7.egg/Products/contentmigration/basemigrator/migrator.py", line 220, in migrate
    method()
  File "/opt/plone/eggs/plone.app.contenttypes-1.2.4-py2.7.egg/plone/app/contenttypes/migration/migration.py", line 201, in last_migrate_layout
    getattr(self.old, 'default_page')
AttributeError: default_page
