### PR TITLE
Change all text getters on plone.app.textfield.value.RichTextValue ob…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ New:
 
 Fixes:
 
-- *add item here*
+- Change all text getters on ``plone.app.textfield.value.RichTextValue``
+  objects to ``output_relative_to`` with the current context. This correctly
+  transforms relative links. See:
+  https://github.com/plone/plone.app.textfield/issues/7
+  [thet]
 
 
 1.2.8 (2015-12-15)

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -119,7 +119,9 @@ class FolderView(BrowserView):
     @property
     def text(self):
         textfield = getattr(aq_base(self.context), 'text', None)
-        text = getattr(textfield, 'output', None)
+        text = textfield.output_relative_to(self.context)\
+            if getattr(textfield, 'output_relative_to', None)\
+            else None
         if text:
             self.text_class = 'stx' if textfield.mimeType in (
                 'text/structured', 'text/x-rst', 'text/restructured'

--- a/plone/app/contenttypes/browser/templates/newsitem.pt
+++ b/plone/app/contenttypes/browser/templates/newsitem.pt
@@ -8,14 +8,13 @@
 <body>
 
 <metal:content-core fill-slot="content-core">
-<metal:block define-macro="content-core"
-    tal:define="templateId template/getId;">
-
+<metal:content-core define-macro="content-core"
+                    tal:define="toc context/table_of_contents|nothing;">
   <div id="parent-fieldname-text"
       tal:condition="context/text"
-      tal:content="structure context/text/output" />
-
-</metal:block>
+      tal:content="structure python:context.text.output_relative_to(view.context)"
+      tal:attributes="class python: toc and 'pat-autotoc' or ''" />
+</metal:content-core>
 </metal:content-core>
 
 </body>


### PR DESCRIPTION
…jects to output_relative_to with the current context. This correctly transforms relative links. See: https://github.com/plone/plone.app.textfield/issues/7

Also see: https://github.com/plone/plone.app.textfield/pull/17

@pbauer - now the templates document.pt and newsitem.pt are completly identical... but merging them together might not be a good idea in terms of BBB compatibility, no?