### PR TITLE
Changes needed in order to use newer robotframework.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Simplifiy test in robot framework which fails in its newer version.
+  [jensens]
 
 
 1.2.9 (2016-01-08)

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -79,8 +79,7 @@ the content area should contain
 
 the content area should not contain
   [Arguments]  ${text}
-  ${passed} =  Run Keyword And Return Status  Element Should Contain  id=content  ${text}
-  Should Not Be True  ${passed}
+  Element Should Not Contain  id=content  ${text}
 
 the collection should contain
   [Arguments]  ${title}


### PR DESCRIPTION
Simplify keyword in robot framework tests which fails in its newer version.
http://jenkins.plone.org/job/pull-request-5.0/703/robot/report/robot_log.html#s1-s27-t1