### PR TITLE
Simplify test-setup of p.a.c

### DIFF
--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -37,11 +37,6 @@ class PloneAppContenttypes(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
-
-        mtr = portal.mimetypes_registry
-        mime_doc = mtr.lookup('application/msword')[0]
-        mime_doc.icon_path = 'custom.png'
-
         portal.acl_users.userFolderAddUser('admin',
                                            'secret',
                                            ['Manager'],

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -8,6 +8,8 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import applyProfile
 from plone.app.testing import login
 from plone.app.testing import setRoles
@@ -37,8 +39,6 @@ class PloneAppContenttypes(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
-        portal.acl_users.userFolderAddUser('admin', 'secret', ['Manager'], [])
-        login(portal, 'admin')
         portal.portal_workflow.setDefaultChain('simple_publication_workflow')
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
@@ -51,6 +51,9 @@ class PloneAppContenttypesRobot(PloneAppContenttypes):
     """
 
     def setUpPloneSite(self, portal):
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+        login(portal, SITE_OWNER_NAME)
         super(PloneAppContenttypesRobot, self).setUpPloneSite(portal)
         portal.invokeFactory('Folder', id=TEST_FOLDER_ID, title=u'Test Folder')
 

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -48,7 +48,7 @@ class PloneAppContenttypesRobot(PloneAppContenttypes):
     """
 
     def setUpPloneSite(self, portal):
-        self.portal.acl_users.userFolderAddUser(
+        portal.acl_users.userFolderAddUser(
             SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
         login(portal, SITE_OWNER_NAME)
         super(PloneAppContenttypesRobot, self).setUpPloneSite(portal)

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -44,17 +44,15 @@ class PloneAppContenttypes(PloneSandboxLayer):
         login(portal, 'admin')
         portal.portal_workflow.setDefaultChain("simple_publication_workflow")
         setRoles(portal, TEST_USER_ID, ['Manager'])
-        portal.invokeFactory(
-            "Folder",
-            id=TEST_FOLDER_ID,
-            title=u"Test Folder"
-        )
 
     def tearDownPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:uninstall')
 
 
 class PloneAppContenttypesMigration(PloneSandboxLayer):
+    """ A setup that installs the old default AT-Types to migrate them to
+    Dexterity. The profile of pac is not only in the individual tests.
+    """
 
     defaultBases = (PLONE_FIXTURE,)
 
@@ -114,6 +112,20 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
         z2.uninstallProduct(app, 'Products.Archetypes')
 
 
+class PloneAppContenttypesRobot(PloneAppContenttypes):
+    """Same as the default but with a added folder 'robot-test-folder'.
+    """
+
+    def setUpPloneSite(self, portal):
+        super(PloneAppContenttypesRobot, self).setUpPloneSite(portal)
+        portal.invokeFactory('Folder', id=TEST_FOLDER_ID, title=u'Test Folder')
+
+    def tearDownPloneSite(self, portal):
+        login(portal, 'admin')
+        portal.manage_delObjects([TEST_FOLDER_ID])
+        super(PloneAppContenttypesRobot, self).tearDownPloneSite(portal)
+
+
 PLONE_APP_CONTENTTYPES_FIXTURE = PloneAppContenttypes()
 PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PLONE_APP_CONTENTTYPES_FIXTURE,),
@@ -133,9 +145,10 @@ PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_FIXTURE,),
     name="PloneAppContenttypes:Migration_Functional"
 )
+PLONE_APP_CONTENTTYPES_ROBOT_FIXTURE = PloneAppContenttypesRobot()
 PLONE_APP_CONTENTTYPES_ROBOT_TESTING = FunctionalTesting(
     bases=(
-        PLONE_APP_CONTENTTYPES_FIXTURE,
+        PLONE_APP_CONTENTTYPES_ROBOT_FIXTURE,
         REMOTE_LIBRARY_BUNDLE_FIXTURE,
         z2.ZSERVER_FIXTURE
     ),

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -7,12 +7,10 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import applyProfile
 from plone.app.testing import login
-from plone.app.testing import setRoles
 from plone.testing import z2
 from zope.interface import alsoProvides
 import pkg_resources
@@ -40,7 +38,6 @@ class PloneAppContenttypes(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
         portal.portal_workflow.setDefaultChain('simple_publication_workflow')
-        setRoles(portal, TEST_USER_ID, ['Manager'])
 
     def tearDownPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:uninstall')

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -37,16 +37,27 @@ class PloneAppContenttypes(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
-        portal.acl_users.userFolderAddUser('admin',
-                                           'secret',
-                                           ['Manager'],
-                                           [])
+        portal.acl_users.userFolderAddUser('admin', 'secret', ['Manager'], [])
         login(portal, 'admin')
-        portal.portal_workflow.setDefaultChain("simple_publication_workflow")
+        portal.portal_workflow.setDefaultChain('simple_publication_workflow')
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
     def tearDownPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:uninstall')
+
+
+class PloneAppContenttypesRobot(PloneAppContenttypes):
+    """Same as the default but with a added folder 'robot-test-folder'.
+    """
+
+    def setUpPloneSite(self, portal):
+        super(PloneAppContenttypesRobot, self).setUpPloneSite(portal)
+        portal.invokeFactory('Folder', id=TEST_FOLDER_ID, title=u'Test Folder')
+
+    def tearDownPloneSite(self, portal):
+        login(portal, 'admin')
+        portal.manage_delObjects([TEST_FOLDER_ID])
+        super(PloneAppContenttypesRobot, self).tearDownPloneSite(portal)
 
 
 class PloneAppContenttypesMigration(PloneSandboxLayer):
@@ -61,7 +72,6 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
         # prepare installing Products.ATContentTypes
         import Products.ATContentTypes
         self.loadZCML(package=Products.ATContentTypes)
-
         z2.installProduct(app, 'Products.Archetypes')
         z2.installProduct(app, 'Products.ATContentTypes')
         z2.installProduct(app, 'plone.app.blob')
@@ -112,38 +122,14 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
         z2.uninstallProduct(app, 'Products.Archetypes')
 
 
-class PloneAppContenttypesRobot(PloneAppContenttypes):
-    """Same as the default but with a added folder 'robot-test-folder'.
-    """
-
-    def setUpPloneSite(self, portal):
-        super(PloneAppContenttypesRobot, self).setUpPloneSite(portal)
-        portal.invokeFactory('Folder', id=TEST_FOLDER_ID, title=u'Test Folder')
-
-    def tearDownPloneSite(self, portal):
-        login(portal, 'admin')
-        portal.manage_delObjects([TEST_FOLDER_ID])
-        super(PloneAppContenttypesRobot, self).tearDownPloneSite(portal)
-
-
 PLONE_APP_CONTENTTYPES_FIXTURE = PloneAppContenttypes()
 PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PLONE_APP_CONTENTTYPES_FIXTURE,),
-    name="PloneAppContenttypes:Integration"
-)
-PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE = PloneAppContenttypesMigration()
-PLONE_APP_CONTENTTYPES_MIGRATION_TESTING = IntegrationTesting(
-    bases=(PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,),
-    name="PloneAppContenttypes:Migration"
+    name='PloneAppContenttypes:Integration'
 )
 PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PLONE_APP_CONTENTTYPES_FIXTURE,),
-    name="PloneAppContenttypes:Functional"
-)
-PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_FIXTURE = PloneAppContenttypesMigration()  # noqa
-PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_FIXTURE,),
-    name="PloneAppContenttypes:Migration_Functional"
+    name='PloneAppContenttypes:Functional'
 )
 PLONE_APP_CONTENTTYPES_ROBOT_FIXTURE = PloneAppContenttypesRobot()
 PLONE_APP_CONTENTTYPES_ROBOT_TESTING = FunctionalTesting(
@@ -152,5 +138,14 @@ PLONE_APP_CONTENTTYPES_ROBOT_TESTING = FunctionalTesting(
         REMOTE_LIBRARY_BUNDLE_FIXTURE,
         z2.ZSERVER_FIXTURE
     ),
-    name="PloneAppContenttypes:Robot"
+    name='PloneAppContenttypes:Robot'
+)
+PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE = PloneAppContenttypesMigration()
+PLONE_APP_CONTENTTYPES_MIGRATION_TESTING = IntegrationTesting(
+    bases=(PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,),
+    name='PloneAppContenttypes:Migration'
+)
+PLONE_APP_CONTENTTYPES_MIGRATION_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,),
+    name='PloneAppContenttypes:Migration_Functional'
 )

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -12,7 +12,6 @@ from plone.app.testing import applyProfile
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.testing import z2
-from zope.configuration import xmlconfig
 from zope.interface import alsoProvides
 import pkg_resources
 
@@ -32,15 +31,9 @@ class PloneAppContenttypes(PloneSandboxLayer):
 
     def setUpZope(self, app, configurationContext):
         import plone.app.contenttypes
-        xmlconfig.file(
-            'configure.zcml',
-            plone.app.contenttypes,
-            context=configurationContext
-        )
-
+        self.loadZCML(package=plone.app.contenttypes)
         import plone.app.event.dx
-        self.loadZCML(package=plone.app.event.dx,
-                      context=configurationContext)
+        self.loadZCML(package=plone.app.event.dx)
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plone.app.contenttypes:default')
@@ -91,23 +84,9 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
         z2.installProduct(app, 'Products.DateRecurringIndex')
 
         import plone.app.contenttypes
-        xmlconfig.file(
-            'configure.zcml',
-            plone.app.contenttypes,
-            context=configurationContext
-        )
+        self.loadZCML(package=plone.app.contenttypes)
         import plone.app.referenceablebehavior
         self.loadZCML(package=plone.app.referenceablebehavior)
-
-    def tearDownZope(self, app):
-        try:
-            pkg_resources.get_distribution('plone.app.collection')
-            z2.uninstallProduct(app, 'plone.app.collection')
-        except pkg_resources.DistributionNotFound:
-            pass
-        z2.uninstallProduct(app, 'plone.app.blob')
-        z2.uninstallProduct(app, 'Products.ATContentTypes')
-        z2.uninstallProduct(app, 'Products.Archetypes')
 
     def setUpPloneSite(self, portal):
         # install Products.ATContentTypes manually if profile is available
@@ -125,6 +104,19 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
             applyProfile(portal, 'plone.app.collection:default')
 
         applyProfile(portal, 'plone.app.referenceablebehavior:default')
+
+    def tearDownPloneSite(self, portal):
+        applyProfile(portal, 'plone.app.contenttypes:uninstall')
+
+    def tearDownZope(self, app):
+        try:
+            pkg_resources.get_distribution('plone.app.collection')
+            z2.uninstallProduct(app, 'plone.app.collection')
+        except pkg_resources.DistributionNotFound:
+            pass
+        z2.uninstallProduct(app, 'plone.app.blob')
+        z2.uninstallProduct(app, 'Products.ATContentTypes')
+        z2.uninstallProduct(app, 'Products.Archetypes')
 
 
 PLONE_APP_CONTENTTYPES_FIXTURE = PloneAppContenttypes()

--- a/plone/app/contenttypes/tests/test_collection.py
+++ b/plone/app/contenttypes/tests/test_collection.py
@@ -204,9 +204,11 @@ class PloneAppCollectionViewsIntegrationTest(unittest.TestCase):
 
     # @unittest.skip("Needs to be refactored")
     def test_collection_templates(self):
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
         browser = self.browser
-        portal = self.layer['portal']
-        login(portal, 'admin')
+        portal = self.portal
+        login(portal, SITE_OWNER_NAME)
         # add an image that will be listed by the collection
         portal.invokeFactory("Image",
                              "image",
@@ -267,8 +269,11 @@ class PloneAppCollectionViewsIntegrationTest(unittest.TestCase):
         self.assertTrue("Image example" in browser.contents)
 
     def test_sorting_1(self):
-        portal = self.layer['portal']
-        login(portal, 'admin')
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+
+        portal = self.portal
+        login(portal, SITE_OWNER_NAME)
         query = [{
             'i': 'portal_type',
             'o': 'plone.app.querystring.operation.string.is',
@@ -313,8 +318,10 @@ class PloneAppCollectionViewsIntegrationTest(unittest.TestCase):
         self.assertTrue(ritem1.CreationDate() > ritem2.CreationDate())
 
     def test_custom_query(self):
-        portal = self.layer['portal']
-        login(portal, 'admin')
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+        portal = self.portal
+        login(portal, SITE_OWNER_NAME)
         query = [{
             'i': 'portal_type',
             'o': 'plone.app.querystring.operation.string.is',
@@ -358,8 +365,10 @@ class PloneAppCollectionViewsIntegrationTest(unittest.TestCase):
         self.assertEqual(len(results), 0)
 
     def test_respect_navigation_root(self):
-        portal = self.layer['portal']
-        login(portal, 'admin')
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+        portal = self.portal
+        login(portal, SITE_OWNER_NAME)
 
         # Create two subsites i.e create two folders and mark them with
         # INavigationRoot

--- a/plone/app/contenttypes/tests/test_file.py
+++ b/plone/app/contenttypes/tests/test_file.py
@@ -1,30 +1,23 @@
 # -*- coding: utf-8 -*-
-import unittest2 as unittest
-
-import os.path
-
-from zope.interface import alsoProvides
-from zope.component import createObject
-from zope.component import queryUtility
-
-from plone.dexterity.interfaces import IDexterityFTI
-
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import SITE_OWNER_PASSWORD
-from plone.testing.z2 import Browser
-
 from plone.app.contenttypes.interfaces import IFile
-
+from plone.app.contenttypes.interfaces import IPloneAppContenttypesLayer
 from plone.app.contenttypes.testing import (
     PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING,
     PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING
 )
-
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID, setRoles
 from plone.app.z3cform.interfaces import IPloneFormLayer
-
+from plone.dexterity.interfaces import IDexterityFTI
 from plone.namedfile.file import NamedFile
-from plone.app.contenttypes.interfaces import IPloneAppContenttypesLayer
+from plone.testing.z2 import Browser
+from zope.component import createObject
+from zope.component import queryUtility
+from zope.interface import alsoProvides
+import os.path
+import unittest2 as unittest
+import transaction
 
 
 class FileIntegrationTest(unittest.TestCase):
@@ -174,6 +167,10 @@ class FileFunctionalTest(unittest.TestCase):
         self.assertTrue('pdf.png' in self.browser.contents)
 
     def test_alternative_mime_icon_doc_for_file(self):
+        mtr = self.portal.mimetypes_registry
+        mime_doc = mtr.lookup('application/msword')[0]
+        mime_doc.icon_path = 'custom.png'
+        transaction.commit()
         self.browser.open(self.portal_url)
         self.browser.getLink('File').click()
 

--- a/plone/app/contenttypes/tests/test_migration.py
+++ b/plone/app/contenttypes/tests/test_migration.py
@@ -55,11 +55,10 @@ class MigrateFromATContentTypesTest(unittest.TestCase):
         self.request['ACTUAL_URL'] = self.portal.absolute_url()
         self.request['URL'] = self.portal.absolute_url()
         self.catalog = getToolByName(self.portal, "portal_catalog")
-        self.portal.acl_users.userFolderAddUser('admin',
-                                                'secret',
-                                                ['Manager'],
-                                                [])
-        login(self.portal, 'admin')
+        self.portal.acl_users.userFolderAddUser(
+            SITE_OWNER_NAME, SITE_OWNER_PASSWORD, ['Manager'], [])
+
+        login(self.portal, SITE_OWNER_NAME)
         self.portal.portal_workflow.setDefaultChain(
             "simple_publication_workflow")
 
@@ -1891,11 +1890,11 @@ class MigrateDexterityBaseClassIntegrationTest(unittest.TestCase):
 
         applyProfile(self.portal, 'plone.app.dexterity:testing')
 
-        self.portal.acl_users.userFolderAddUser('admin',
-                                                'secret',
+        self.portal.acl_users.userFolderAddUser(SITE_OWNER_NAME,
+                                                SITE_OWNER_PASSWORD,
                                                 ['Manager'],
                                                 [])
-        login(self.portal, 'admin')
+        login(self.portal, SITE_OWNER_NAME)
 
         # Add default content
         self.portal.invokeFactory('Document', 'item')
@@ -1956,7 +1955,6 @@ class MigrateDexterityBaseClassFunctionalTest(unittest.TestCase):
         app = self.layer['app']
         self.portal = self.layer['portal']
         self.request = self.layer['request']
-
         self.portal_url = self.portal.absolute_url()
         self.manage_document_url = '{0}/{1}/{2}/{3}'.format(
             self.portal_url,
@@ -2017,11 +2015,11 @@ class MigrationFunctionalTests(unittest.TestCase):
         self.request['ACTUAL_URL'] = self.portal.absolute_url()
         self.request['URL'] = self.portal.absolute_url()
         self.catalog = getToolByName(self.portal, "portal_catalog")
-        self.portal.acl_users.userFolderAddUser('admin',
-                                                'secret',
+        self.portal.acl_users.userFolderAddUser(SITE_OWNER_NAME,
+                                                SITE_OWNER_PASSWORD,
                                                 ['Manager'],
                                                 [])
-        login(self.portal, 'admin')
+        login(self.portal, SITE_OWNER_NAME)
         self.portal.portal_workflow.setDefaultChain(
             "simple_publication_workflow")
         self.portal_url = self.portal.absolute_url()


### PR DESCRIPTION
``PLONE_APP_CONTENTTYPES_FIXTURE`` is used by many packages as a base to test against dexterity-types. But the test-setup of p.a.c. has grown historically and contains some useless things that might produce issues with other tests and with test-isolation. These commits try to simplify the test-setup and make it follow best-practices.

Do not merge yet.