### PR TITLE
Fix leadimage migration for 1.1.x

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -96,3 +96,4 @@ selenium = 2.46.0
 
 # pin to officially supported version
 plone.app.event = <= 1.1.999
+createcoverage = 1.3.2

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Check if there is an image into leadimage field for migration.
+  [bsuttor]
 
 
 1.1 (2015-12-22)

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -207,6 +207,12 @@ def migrate_leadimage(source_object, target_object):
                     "Could not migrate collective.leadimage fields.")
         return
 
+    acc = source_object.getField(
+        OLD_LEADIMAGE_FIELD_NAME).getAccessor(source_object)()
+    if not acc.filename:
+        # skip if old content has field but has no lead image in the field
+        return
+
     # handle image field
     migrate_imagefield(
         source_object,
@@ -221,7 +227,8 @@ def migrate_leadimage(source_object, target_object):
         OLD_CAPTION_FIELD_NAME,
         NEW_CAPTION_FIELD_NAME)
     logger.info(
-        "Migrating contentlead image for." % target_object.absolute_url())
+        "Migrating contentlead image for {0}.".format(
+            target_object.absolute_url()))
 
 
 def migrate_portlets(src_obj, dst_obj):

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -209,7 +209,7 @@ def migrate_leadimage(source_object, target_object):
 
     acc = source_object.getField(
         OLD_LEADIMAGE_FIELD_NAME).getAccessor(source_object)()
-    if not acc.filename:
+    if getattr(acc, 'filename', None) is not None:
         # skip if old content has field but has no lead image in the field
         return
 


### PR DESCRIPTION
Check if there is an image into leadimage field for migration.
At the moment, migration will add an `None` image if some object have old `collective.contentleadimage` field with no image registered in that field.

And after migration, we obviously have some errors when we try to get leadimage :

    AttributeError: 'NoneType' object has no attribute 'tag' 

I would like to make a test for this, but for that I have to add dependency with collective.contentleadimage. And I think we don't want to have this dependency.