### PR TITLE
Made xpath expression in test less restrictive.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New:
 
 Fixes:
 
+- Made xpath expression in test less restrictive.
+  [maurits]
+
 - Register explicitly plone.app.event dependency on configure.zcml.
   [hvelarde]
 

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -83,8 +83,8 @@ the content area should not contain
 
 the collection should contain
   [Arguments]  ${title}
-  Wait until page contains element  xpath=//section[@id='content-core']
-  xpath should match x times  //section[@id='content-core']//*[@class='entry']//a[contains(text(), '${title}')]  1
+  Wait until page contains element  xpath=//*[@id='content-core']
+  xpath should match x times  //*[@id='content-core']//*[@class='entry']//a[contains(text(), '${title}')]  1
 
 
 the collection should not contain


### PR DESCRIPTION
This test was looking for a section with an id, but we should just look for an id.

There is a pull request in CMFPlone for changing the section back to a div,
and the tests would fail if that gets merged.
See https://github.com/plone/Products.CMFPlone/issues/1431

This pull request is part of https://github.com/plone/Products.CMFPlone/issues/1430