### PR TITLE
Fix multilingual empty view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,11 @@ Bug fixes:
 - Fixed possible cross site scripting (XSS) attack in news item image caption.  [maurits]
 - Check if LingaPlone is installed for adding Language='all' option of 
   query catalog used to migration. No more for plone.app.multilingual.
+- If Products.LingaPlone is in site packages, we adding Language='all' option 
+  for query catalog used to migration. Before, it was also check if 
+  plone.app.multilingual is in packages, but plone.app.multilingual does not 
+  support Language='all' option.
+  see https://github.com/plone/plone.app.multilingual/issues/226
   [bsuttor]
 
 - Register explicitly plone.app.event dependency on configure.zcml.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Bug fixes:
 Bug fixes:
 
 - Fixed possible cross site scripting (XSS) attack in news item image caption.  [maurits]
+- Check if LingaPlone is installed for adding Language='all' option of 
+  query catalog used to migration. No more for plone.app.multilingual.
+  [bsuttor]
 
 - Register explicitly plone.app.event dependency on configure.zcml.
   [hvelarde]

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -21,7 +21,7 @@ from plone.app.contenttypes.migration import dxmigration
 from plone.app.contenttypes.migration import migration
 from plone.app.contenttypes.migration.patches import \
     patched_insertForwardIndexEntry
-from plone.app.contenttypes.migration.utils import HAS_MULTILINGUAL
+from plone.app.contenttypes.migration.utils import HAS_LINGUA_PLONE
 from plone.app.contenttypes.migration.utils import installTypeIfNeeded
 from plone.app.contenttypes.migration.utils import isSchemaExtended
 from plone.app.contenttypes.migration.utils import restore_references
@@ -94,7 +94,7 @@ class FixBaseClasses(BrowserView):
         ]
         catalog = getToolByName(self.context, "portal_catalog")
         query = {}
-        if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+        if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
             query['Language'] = 'all'
         for portal_type, portal_type_class in portal_types:
             query['portal_type'] = portal_type
@@ -205,7 +205,7 @@ class MigrateFromATContentTypes(BrowserView):
                 'object_provides': v['iface'].__identifier__,
                 'meta_type': v['old_meta_type'],
             }
-            if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+            if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
                 query['Language'] = 'all'
             amount_to_be_migrated = len(catalog(query))
             starttime_for_current = datetime.now()
@@ -295,7 +295,7 @@ class MigrateFromATContentTypes(BrowserView):
         results = {}
         query = {}
         catalog = self.context.portal_catalog
-        if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+        if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
             query['Language'] = 'all'
         for brain in catalog(query):
             classname = brain.getObject().__class__.__name__
@@ -486,7 +486,7 @@ class ATCTMigratorHelpers(BrowserView):
         """ Return the number of AT objects in the portal """
         catalog = getToolByName(self.context, "portal_catalog")
         query = {'meta_type': [i['old_meta_type'] for i in ATCT_LIST.values()]}
-        if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+        if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
             query['Language'] = 'all'
         brains = catalog(query)
         self._objects_to_be_migrated = len(brains)
@@ -517,7 +517,7 @@ class ATCTMigratorHelpers(BrowserView):
         catalog = getToolByName(self.context, "portal_catalog")
         query = {'meta_type': 'ATTopic'}
         results = []
-        if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+        if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
             query['Language'] = 'all'
         brains = catalog(query)
         for brain in brains:

--- a/plone/app/contenttypes/migration/dxmigration.py
+++ b/plone/app/contenttypes/migration/dxmigration.py
@@ -5,7 +5,7 @@ from Products.contentmigration.basemigrator.migrator import CMFItemMigrator
 from Products.contentmigration.basemigrator.walker import CatalogWalker
 from plone.app.contenttypes.interfaces import IEvent
 from plone.app.contenttypes.migration.field_migrators import datetime_fixer
-from plone.app.contenttypes.migration.utils import HAS_MULTILINGUAL
+from plone.app.contenttypes.migration.utils import HAS_LINGUA_PLONE
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.event.utils import default_timezone
@@ -172,7 +172,7 @@ def migrate_base_class_to_new_class(obj,
 def list_of_objects_with_changed_base_class(context):
     catalog = getToolByName(context, "portal_catalog")
     query = {'object_provides': IDexterityContent.__identifier__}
-    if HAS_MULTILINGUAL and 'Language' in catalog.indexes():
+    if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
         query['Language'] = 'all'
     for brain in catalog(query):
         try:

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -56,17 +56,9 @@ logger = logging.getLogger(__name__)
 try:
     pkg_resources.get_distribution('Products.LinguaPlone')
 except pkg_resources.DistributionNotFound:
-    HAS_MULTILINGUAL = False
+    HAS_LINGUA_PLONE = False
 else:
-    HAS_MULTILINGUAL = True
-
-if not HAS_MULTILINGUAL:
-    try:
-        pkg_resources.get_distribution('plone.app.multilingual')
-    except pkg_resources.DistributionNotFound:
-        HAS_MULTILINGUAL = False
-    else:
-        HAS_MULTILINGUAL = True
+    HAS_LINGUA_PLONE = True
 
 
 def isSchemaExtended(iface):


### PR DESCRIPTION
As refered in this issue for plone app multilingual : https://github.com/plone/plone.app.multilingual/issues/226

These 2 variables :
- plone.app.contenttypes.migration.utils.HAS_MULTILINGUAL becomes plone.app.contenttypes.migration.utils.HAS_LINGUA_PLONE
- Products.contentmigration.common.HAS_LINGUA_PLONE
  
  only check if LinguaPlone is installed

I'm willing to write tests too, but I don't know who to write it, in plone app contenttypes ? in plone app multilingual ?

(This PR is also related to this https://github.com/plone/Products.contentmigration/pull/9)
