### PR TITLE
Add leadimage settings 1.1.x

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Add leadimage settings.
+  [bsuttor]
+
 - Register explicitly plone.app.event dependency on configure.zcml.
   [hvelarde]
 

--- a/plone/app/contenttypes/behaviors/leadimage.pt
+++ b/plone/app/contenttypes/behaviors/leadimage.pt
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <div class="leadImage" tal:condition="view/available">
   <img tal:define="has_img context/image|nothing;
                    scales context/@@images|nothing"

--- a/plone/app/contenttypes/behaviors/leadimage.pt
+++ b/plone/app/contenttypes/behaviors/leadimage.pt
@@ -1,6 +1,7 @@
+<<<<<<< HEAD
 <div class="leadImage" tal:condition="view/available">
   <img tal:define="has_img context/image|nothing;
                    scales context/@@images|nothing"
-       tal:condition="python:has_img and scales" 
-       tal:replace="structure python: scales.scale('image', scale='mini').tag(css_class='newsImage')" />
+       tal:condition="python:has_img and scales"
+       tal:replace="structure python: scales.scale('image', scale=view.scale_name).tag(css_class='leadImage')" />
 </div>

--- a/plone/app/contenttypes/behaviors/leadimage.py
+++ b/plone/app/contenttypes/behaviors/leadimage.py
@@ -32,3 +32,19 @@ class LeadImage(object):
 
     def __init__(self, context):
         self.context = context
+
+
+class ILeadImageSettings(Interface):
+
+    scale_name = schema.Choice(
+        title=_(u"Image scale"),
+        description=_(u'Please select scale which will be used.'),
+        required=True,
+        default='mini',
+        vocabulary=u"plone.app.vocabularies.ImagesScales",
+    )
+
+    is_visible = schema.Bool(
+        title=_(u'Show image in content'),
+        default=True,
+    )

--- a/plone/app/contenttypes/behaviors/leadimage.py
+++ b/plone/app/contenttypes/behaviors/leadimage.py
@@ -7,6 +7,7 @@ from plone.supermodel import model
 from zope import schema
 from zope.component import adapter
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.interface import provider
 
 

--- a/plone/app/contenttypes/behaviors/viewlets.py
+++ b/plone/app/contenttypes/behaviors/viewlets.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.behaviors.leadimage import ILeadImage
-from plone.app.contenttypes.interfaces import INewsItem
 from plone.app.layout.viewlets import ViewletBase
 from plone.app.contenttypes.behaviors.leadimage import ILeadImageSettings
 from plone import api
@@ -27,7 +26,5 @@ class LeadImageViewlet(ViewletBase):
     @property
     def scale_name(self):
         return api.portal.get_registry_record(
-                'scale_name',
-                interface=ILeadImageSettings)
-
-
+            'scale_name',
+            interface=ILeadImageSettings)

--- a/plone/app/contenttypes/behaviors/viewlets.py
+++ b/plone/app/contenttypes/behaviors/viewlets.py
@@ -2,6 +2,8 @@
 from plone.app.contenttypes.behaviors.leadimage import ILeadImage
 from plone.app.contenttypes.interfaces import INewsItem
 from plone.app.layout.viewlets import ViewletBase
+from plone.app.contenttypes.behaviors.leadimage import ILeadImageSettings
+from plone import api
 
 
 class LeadImageViewlet(ViewletBase):
@@ -9,6 +11,23 @@ class LeadImageViewlet(ViewletBase):
 
     def update(self):
         self.context = ILeadImage(self.context)
-        self.available = True if self.context.image else False
-        if INewsItem.providedBy(self.context):
-            self.available = False
+        self.available = self.is_visible
+
+    @property
+    def is_visible(self):
+        visible = False
+        if self.context.image:
+            is_visible = api.portal.get_registry_record(
+                'is_visible',
+                interface=ILeadImageSettings)
+            if is_visible:
+                visible = True
+        return visible
+
+    @property
+    def scale_name(self):
+        return api.portal.get_registry_record(
+                'scale_name',
+                interface=ILeadImageSettings)
+
+

--- a/plone/app/contenttypes/profiles/default/metadata.xml
+++ b/plone/app/contenttypes/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1104</version>
+ <version>1105</version>
  <dependencies>
   <dependency>profile-plone.app.dexterity:default</dependency>
   <dependency>profile-plone.app.event:default</dependency>

--- a/plone/app/contenttypes/profiles/default/registry.xml
+++ b/plone/app/contenttypes/profiles/default/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <records interface="plone.app.contenttypes.behaviors.leadimage.ILeadImageSettings"/>
+</registry>

--- a/plone/app/contenttypes/profiles/uninstall/registry.xml
+++ b/plone/app/contenttypes/profiles/uninstall/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <records interface="plone.app.contenttypes.behaviors.leadimage.ILeadImageSettings" remove="True" />
+</registry>

--- a/plone/app/contenttypes/tests/test_behaviors_leadimage.py
+++ b/plone/app/contenttypes/tests/test_behaviors_leadimage.py
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
-import os
-import unittest2 as unittest
-
+from plone import api
+from plone.app.contenttypes.behaviors.leadimage import ILeadImageSettings
+from plone.app.contenttypes.interfaces import IPloneAppContenttypesLayer
+from plone.app.contenttypes.testing import (
+    PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING)
+from plone.app.contenttypes.testing import (
+    PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING)
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
-from plone.testing.z2 import Browser
-
-from plone.app.contenttypes.testing import (
-    PLONE_APP_CONTENTTYPES_FUNCTIONAL_TESTING
-)
-
-from plone.app.contenttypes.interfaces import IPloneAppContenttypesLayer
-from zope.interface import alsoProvides
-
-from plone.dexterity.fti import DexterityFTI
-
 from plone.app.testing import TEST_USER_ID, setRoles
+from plone.dexterity.fti import DexterityFTI
+from plone.testing.z2 import Browser
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.viewlet.interfaces import IViewletManager
+
+import os
+import unittest
 
 
 class LeadImageBehaviorFunctionalTest(unittest.TestCase):
@@ -82,3 +83,126 @@ class LeadImageBehaviorFunctionalTest(unittest.TestCase):
         # But doesn't show up on folder_contents, which is not a default view
         self.browser.open(self.portal_url + '/leadimagefolder/folder_contents')
         self.assertTrue('<div class="leadImage">' not in self.browser.contents)
+
+
+class LeadImageBehaviorIntegrationtTest(unittest.TestCase):
+
+    layer = PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+        fti = DexterityFTI('leadimagefolder')
+        self.portal.portal_types._setObject('leadimagefolder', fti)
+        fti.klass = 'plone.dexterity.content.Container'
+        fti.behaviors = (
+            'plone.app.contenttypes.behaviors.leadimage.ILeadImage',
+        )
+        self.fti = fti
+        alsoProvides(self.portal.REQUEST, IPloneAppContenttypesLayer)
+        alsoProvides(self.request, IPloneAppContenttypesLayer)
+        from plone.app.contenttypes.behaviors.leadimage import ILeadImage
+        alsoProvides(self.request, ILeadImage)
+        self.portal.invokeFactory(
+            'leadimagefolder',
+            id='leadimagefolder',
+            title=u'Folder with a lead image'
+        )
+
+    def test_lead_image_viewlet_settings(self):
+        is_visible = api.portal.get_registry_record(
+            'is_visible',
+            interface=ILeadImageSettings)
+        self.assertTrue(is_visible)
+
+        api.portal.set_registry_record(
+            'is_visible',
+            False,
+            interface=ILeadImageSettings)
+        is_visible = api.portal.get_registry_record(
+            'is_visible',
+            interface=ILeadImageSettings)
+        self.assertFalse(is_visible)
+
+        scale_name = api.portal.get_registry_record(
+            'scale_name',
+            interface=ILeadImageSettings)
+        self.assertEqual(scale_name, 'mini')
+
+    def test_lead_image_preferences(self):
+        container = api.content.get('/leadimagefolder')
+
+        # Image upload
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        add_leadimage_from_file_path(container, file_path)
+
+        self.request.set('URL', container.absolute_url())
+        self.request.set('ACTUAL_URL', container.absolute_url())
+
+        view = container.restrictedTraverse('view')
+        view.update()
+        self.assertTrue(
+            'class="leadImage"' in view.render(),
+            'Leadimage should be visible.')
+
+        api.portal.set_registry_record(
+            'is_visible',
+            False,
+            interface=ILeadImageSettings)
+        view.update()
+        self.assertTrue(
+            'class="leadImage"' not in view.render(),
+            'Leadimage should not be visible.')
+
+    def test_lead_image_viewlet_view(self):
+        container = api.content.get('/leadimagefolder')
+
+        # Image upload
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        add_leadimage_from_file_path(container, file_path)
+
+        self.request.set('URL', container.absolute_url())
+        self.request.set('ACTUAL_URL', container.absolute_url())
+
+        view = container.restrictedTraverse('view')
+        view.update()
+        self.assertTrue(view.render())
+
+        manager_name = 'plone.abovecontenttitle'
+        manager = queryMultiAdapter(
+            (container, self.request, view),
+            IViewletManager, manager_name, default=None)
+        self.assertIsNotNone(manager)
+        manager.update()
+        viewlet = [v for v in manager.viewlets
+                   if v.__name__ == 'contentleadimage']
+        self.assertEqual(len(viewlet), 1)
+
+        lead_viewlet = viewlet[0]
+        self.assertEqual(lead_viewlet.scale_name, 'mini')
+        self.assertTrue(lead_viewlet.available)
+        is_visible = api.portal.set_registry_record(
+            'is_visible',
+            False,
+            interface=ILeadImageSettings)
+        self.assertFalse(is_visible)
+
+
+def add_leadimage_from_file_path(obj, file_path):
+    file_name = file_path.split(os.sep)[-1]
+    if not obj.hasObject(file_name):
+        from plone.namedfile.file import NamedBlobImage
+        namedblobimage = NamedBlobImage(
+            data=open(file_path, 'r').read(),
+            filename=unicode(file_name)
+        )
+        image = api.content.create(type='Image',
+                                   title=file_name,
+                                   image=namedblobimage,
+                                   container=api.portal.get(),
+                                   language='fr')
+        image.setTitle(file_name)
+        image.reindexObject()
+        setattr(obj, 'image', namedblobimage)

--- a/plone/app/contenttypes/upgrades.py
+++ b/plone/app/contenttypes/upgrades.py
@@ -206,3 +206,9 @@ def use_new_view_names(context, types_to_fix=None):  # noqa
             _fixup(obj, LISTING_VIEW_MAPPING)
         if portal_type == 'Plone Site':
             _fixup(context, LISTING_VIEW_MAPPING)
+
+
+def add_leadimage_settings(context):
+    context.runImportStepFromProfile(
+        'profile-plone.app.contenttypes:default',
+        'plone.app.registry')

--- a/plone/app/contenttypes/upgrades.zcml
+++ b/plone/app/contenttypes/upgrades.zcml
@@ -72,4 +72,13 @@
       handler=".upgrades.use_new_view_names"
       />
 
+  <genericsetup:upgradeStep
+      source="1104"
+      destination="1105"
+      title="Add leadimage settings"
+      description=""
+      profile="plone.app.contenttypes:default"
+      handler=".upgrades.add_leadimage_settings"
+      />
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
 import os
@@ -55,6 +56,7 @@ setup(name='plone.app.contenttypes',
           'Products.CMFQuickInstallerTool >= 3.0.7',  # allow blacklisting steps
           'Products.GenericSetup >= 1.7.5',  # allow blacklisting steps
           'zope.deprecation',
+          'plone.api',
       ] + additional_requires,
       extras_require={
           'test': [


### PR DESCRIPTION
Leadimage settings are usefull for migration from archetypes to dexterity in Plone 4.3.x.
Indeed, these options are avaiable in collective.contentleadimage
