### PR TITLE
Adding links and removing typos under 'Migration' section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,18 +4,15 @@ Changelog
 1.2.12 (unreleased)
 -------------------
 
-Incompatibilities:
-
-- *add item here*
-
 New:
 
-- *add item here*
+- added few pypi links in 'Migration' section
+  [kkhan]
 
 Fixes:
 
-- *add item here*
-
+- corrected typos in the documentation
+  [kkhan]
 
 1.2.11 (2016-03-31)
 -------------------

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -159,7 +159,7 @@ To migrate your existing content from Archetypes to Dexterity use the form at ``
 Migrating Archetypes-based default-types content to plone.app.contenttypes
 ``````````````````````````````````````````````````````````````````````````
 
-plone.app.contenttypes can migrate the following archetypes-based default types:
+`plone.app.contenttypes<https://pypi.python.org/pypi/plone.app.contenttypes/1.2.5/>`_ can migrate the following archetypes-based default types:
 
 * Document
 * Event
@@ -229,11 +229,11 @@ Migrating content that is translated with LinguaPlone
 Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
 
 
-Migrating default-content that was extended with *schemaextender*
+Migrating default-content that was extended with archetypes.schemaextender
 ``````````````````````````````````````````````````````````````````````````
 
 
-The migration-form warns you if any of your old types were extended with aditional fields using archetypes.schemaextender. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
+The migration-form warns you if any of your old types were extended with aditional fields using `archetypes.schemaextender<https://pypi.python.org/pypi/archetypes.schemaextender/2.1.5/>`_. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
 
 To keep the data you would need to write a custom migration for your types dexterity-behaviors for the functionality provided by the schemaextenders. This is an advanced development task and beyond the scope of this documentation.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -229,10 +229,9 @@ Migrating content that is translated with LinguaPlone
 Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
 
 
-Migrating default-content that was extended with 
+Migrating default-content that was extended with `schemaextender`
 ``````````````````````````````````````````````````````````````````````````
-archetypes.schemaextender
-``````````````````````````````````````````````````````````````````````````
+
 
 The migration-form warns you if any of your old types were extended with aditional fields using archetypes.schemaextender. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -159,7 +159,7 @@ To migrate your existing content from Archetypes to Dexterity use the form at ``
 Migrating Archetypes-based default-types content to plone.app.contenttypes
 ``````````````````````````````````````````````````````````````````````````
 
-`plone.app.contenttypes<https://pypi.python.org/pypi/plone.app.contenttypes/1.2.5/>`_ can migrate the following archetypes-based default types:
+`plone.app.contenttypes <https://pypi.python.org/pypi/plone.app.contenttypes/>`_ can migrate the following archetypes-based default types:
 
 * Document
 * Event
@@ -233,7 +233,7 @@ Migrating default-content that was extended with archetypes.schemaextender
 ``````````````````````````````````````````````````````````````````````````
 
 
-The migration-form warns you if any of your old types were extended with aditional fields using `archetypes.schemaextender<https://pypi.python.org/pypi/archetypes.schemaextender/2.1.5/>`_. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
+The migration-form warns you if any of your old types were extended with aditional fields using `archetypes.schemaextender   <https://pypi.python.org/pypi/archetypes.schemaextender/>`_. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
 
 To keep the data you would need to write a custom migration for your types dexterity-behaviors for the functionality provided by the schemaextenders. This is an advanced development task and beyond the scope of this documentation.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -229,7 +229,9 @@ Migrating content that is translated with LinguaPlone
 Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
 
 
-Migrating default-content that was extended with archetypes.schemaextender
+Migrating default-content that was extended with 
+``````````````````````````````````````````````````````````````````````````
+archetypes.schemaextender
 ``````````````````````````````````````````````````````````````````````````
 
 The migration-form warns you if any of your old types were extended with aditional fields using archetypes.schemaextender. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -229,7 +229,7 @@ Migrating content that is translated with LinguaPlone
 Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
 
 
-Migrating default-content that was extended with `schemaextender`
+Migrating default-content that was extended with *schemaextender*
 ``````````````````````````````````````````````````````````````````````````
 
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -226,14 +226,15 @@ The migration-form will warn you if you have subtopics in your site and your Col
 Migrating content that is translated with LinguaPlone
 `````````````````````````````````````````````````````
 
-Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
+Since LinguaPlone does not support Dexterity you need to migrate from LinguaPlone to plone.app.multilingual (http://pypi.python.org/pypi/plone.app.multilingual). The migration from Products.LinguaPlone to plone.app.multilingual should happen **before** the migration from Archetypes to plone.app.contenttypes. For details on the migration see--
+http://pypi.python.org/pypi/plone.app.multilingual#linguaplone-migration
 
 
 Migrating default-content that was extended with archetypes.schemaextender
 ``````````````````````````````````````````````````````````````````````````
 
 
-The migration-form warns you if any of your old types were extended with aditional fields using `archetypes.schemaextender   <https://pypi.python.org/pypi/archetypes.schemaextender/>`_. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
+The migration-form warns you if any of your old types were extended with additional fields using `archetypes.schemaextender   <https://pypi.python.org/pypi/archetypes.schemaextender/>`_. The data contained in these fields will be lost during migration (with the exception of images added with collective.contentleadimage).
 
 To keep the data you would need to write a custom migration for your types dexterity-behaviors for the functionality provided by the schemaextenders. This is an advanced development task and beyond the scope of this documentation.
 


### PR DESCRIPTION
currently, a direct link to  `collective.contentleadimage` only is present in this section. 
imo its better to add direct link to all pypi packages that are referenced in this section, just to make it easier for users to view them.