### PR TITLE
Encode the absolute_target_url as utf-8 string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Fixes:
 
 - *add item here*
 
+- Encode the linked url for the Link type to allow for non ascii characters in the url. 
+  [martior]
+
 
 1.2.11 (2016-03-31)
 -------------------

--- a/plone/app/contenttypes/browser/link_redirect_view.py
+++ b/plone/app/contenttypes/browser/link_redirect_view.py
@@ -53,7 +53,7 @@ class LinkRedirectView(BrowserView):
             and not self._url_uses_scheme(NON_REDIRECTABLE_URL_SCHEMES)
 
         if redirect_links and not can_edit:
-            return self.request.RESPONSE.redirect(self.absolute_target_url())
+            return self.request.RESPONSE.redirect(self.absolute_target_url().encode('utf-8'))
         else:
             return self.index()
 


### PR DESCRIPTION
This is to make sure url can be converted to string lower in the stack. If not you can get errors like:
Traceback (innermost last): 
Module ZPublisher.Publish, line 138, in publish 
Module ZPublisher.mapply, line 77, in mapply 
Module ZPublisher.Publish, line 48, in call_object 
Module plone.app.contenttypes.browser.link_redirect_view, line 56, in __call__ 
Module ZPublisher.HTTPResponse, line 609, in redirect 
Module ZPublisher.HTTPResponse, line 331, in setHeader 
Module ZPublisher.HTTPResponse, line 134, in _scrubHeader 
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 37: ordinal not in range(128)