### PR TITLE
Don't fail replace_link_variables_by_paths with empty value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Don't fail for ``utils.replace_link_variables_by_paths``, if value is ``None``.
+  The value can be ``None`` when creating a ``Link`` type with ``invokeFactory`` without ``remoteUrl`` set and calling the indexer before setting the URL.
+  [thet]
 
 
 1.2.12 (2016-04-13)

--- a/plone/app/contenttypes/utils.py
+++ b/plone/app/contenttypes/utils.py
@@ -17,6 +17,9 @@ def replace_link_variables_by_paths(context, url):
     "${portal_url}" by the corresponding paths. `context` is the acquisition
     context.
     """
+    if not url:
+        return None
+
     portal_state = context.restrictedTraverse('@@plone_portal_state')
 
     if '${navigation_root_url}' in url:

--- a/plone/app/contenttypes/utils.py
+++ b/plone/app/contenttypes/utils.py
@@ -18,7 +18,7 @@ def replace_link_variables_by_paths(context, url):
     context.
     """
     if not url:
-        return None
+        return url
 
     portal_state = context.restrictedTraverse('@@plone_portal_state')
 


### PR DESCRIPTION
Don't fail for ``utils.replace_link_variables_by_paths``, if value is ``None``.
The value can be ``None`` when creating a ``Link`` type with ``invokeFactory`` without ``remoteUrl`` set and calling the indexer before setting the URL.

Was the case for a custom type using ``<property name="klass">plone.app.contenttypes.content.Link</property>`` in the FTI but not for using the ``Link`` type directly. Both were created with transmogrifier without a ``remoteUrl`` set, which is set afterwards by ``transmogrify.dexterity.schemaupdater`` blueprint.