### PR TITLE
Fixed unstable robot test for location criterion.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New:
 
 Fixes:
 
+- Fixed unstable robot test for location criterion.  [maurits]
+
 - Don't fail for ``utils.replace_link_variables_by_paths``, if value is ``None``.
   The value can be ``None`` when creating a ``Link`` type with ``invokeFactory`` without ``remoteUrl`` set and calling the indexer before setting the URL.
   [thet]

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -120,3 +120,7 @@ I set the criteria ${type} in row ${number} to the options '${label}'
 I set the criteria ${type} in row ${number} to the text '${label}'
   ${criteria_row} =  Convert to String  .querystring-criteria-wrapper:nth-child(${number})
   Input text  css=${criteria_row} .querystring-criteria-value input  ${label}\t
+  [Documentation]  Shift the focus so the input sticks, and wait a bit
+  Sleep  0.5
+  Focus  css=.querystring-sortreverse
+  Sleep  0.5

--- a/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
@@ -84,6 +84,5 @@ I set the collection's absolute location criterion to
     I set the criteria operator in row 1 to the option 'Absolute path'
     I set the criteria value in row 1 to the text '${criterion}'
 
-    Sleep  1
     Click Button  Save
     Wait until page contains  Changes saved


### PR DESCRIPTION
Especially the relative path criterion sometimes failed on Jenkins during this test:

  And the collection should not contain 'Document outside Folder'

For example: http://jenkins.plone.org/job/plone-5.1-python-2.7-robot/293/

Locally for me, it *always* failed.  When debugging, it appeared that the addition of the relative path criterion did not finish before clicking Save.

The absolute path criterion test usually passed, and this was likely because this had a pause of one second before clicking save on the collection edit form.  But this sometimes failed too, at least locally.

Solution is now to always do this:
- pause half a second
- change the focus (we choose the 'Sort reversed' checkbox)
- pause another half second
- then click Save

This does the trick locally, and hopefully on Jenkins too.
