### PR TITLE
deferred initialize to reduce costs of adapter lookup.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New:
 
 Fixes:
 
+- Deferred adapter lookup in collection view.
+  This was looked up for contentmenu/toolbar at every authenticated request.
+  It also had side effects if custom collection behaviors are used.
+  [jensens]
+
 - Fixed unstable robot test for location criterion.  [maurits]
 
 - Don't fail for ``utils.replace_link_variables_by_paths``, if value is ``None``.

--- a/plone/app/contenttypes/browser/collection.py
+++ b/plone/app/contenttypes/browser/collection.py
@@ -10,11 +10,18 @@ from plone.memoize.view import memoize
 
 class CollectionView(FolderView):
 
-    def __init__(self, *args, **kwargs):
-        super(CollectionView, self).__init__(*args, **kwargs)
-        context = aq_inner(self.context)
-        self.collection_behavior = ICollection(context)
-        self.b_size = self.collection_behavior.item_count
+    @property
+    def collection_behavior(self):
+        return ICollection(aq_inner(self.context))
+
+    @property
+    def b_size(self):
+        return getattr(self, '_b_size', self.collection_behavior.item_count)
+
+    @b_size.setter
+    def b_size(self, value):
+        # ignore, FolderView tries to set on init
+        pass
 
     def results(self, **kwargs):
         """Return a content listing based result set with results from the


### PR DESCRIPTION
this also has side effects on subclassed collection implementations.