### PR TITLE
Wait longer to fix unstable robot tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Wait longer to fix unstable robot tests.  [maurits]
 
 
 1.2.15 (2016-06-06)

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -121,6 +121,6 @@ I set the criteria ${type} in row ${number} to the text '${label}'
   ${criteria_row} =  Convert to String  .querystring-criteria-wrapper:nth-child(${number})
   Input text  css=${criteria_row} .querystring-criteria-value input  ${label}\t
   [Documentation]  Shift the focus so the input sticks, and wait a bit
-  Sleep  0.5
+  Sleep  1.5
   Focus  css=.querystring-sortreverse
-  Sleep  0.5
+  Sleep  1.5


### PR DESCRIPTION
Yes, it is annoying to wait longer, and should not be needed, or there should be better ways.

But to me it is far more annoying to have unrelated pull requests tests fail because of timing issues.  Not only on Jenkins: I sometimes have failures locally.
Sample Jenkins failure: http://jenkins.plone.org/job/pull-request-5.0/1215/

I have the feeling that pull requests suffer more from this than the normal tests, which are more split out over various jobs, but that is just a feeling.