### PR TITLE
configure edit urls for locking support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Configure edit urls for locking support, where locking support is enabled.
   [thet]
 
+- Add ``i18n:attribute`` properies to all action nodes for FTI types.
+  [thet]
+
 Bug fixes:
 
 - Select all migratable types in migration-form by default. Fixes #193.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Configure edit urls for locking support, where locking support is enabled.
+  [thet]
 
 Bug fixes:
 
@@ -398,7 +399,7 @@ Fixes:
 - Provide table of contents for document view.
   [vangheem]
 
-- Default to using locking support on Page, Collection, Event and News Item types
+- Default to using locking support on Page, Collection, Event and News Item types.
   [vangheem]
 
 - Show the LeadImageViewlet only on default views.

--- a/plone/app/contenttypes/profiles/default/types/Collection.xml
+++ b/plone/app/contenttypes/profiles/default/types/Collection.xml
@@ -88,7 +88,7 @@
   <action
       action_id="edit"
       category="object"
-      condition_expr=""
+      condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Collection.xml
+++ b/plone/app/contenttypes/profiles/default/types/Collection.xml
@@ -80,6 +80,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -89,6 +90,7 @@
       action_id="edit"
       category="object"
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Document.xml
+++ b/plone/app/contenttypes/profiles/default/types/Document.xml
@@ -84,7 +84,7 @@
   <action
       action_id="edit"
       category="object"
-      condition_expr=""
+      condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Document.xml
+++ b/plone/app/contenttypes/profiles/default/types/Document.xml
@@ -76,6 +76,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -85,6 +86,7 @@
       action_id="edit"
       category="object"
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Event.xml
+++ b/plone/app/contenttypes/profiles/default/types/Event.xml
@@ -88,7 +88,7 @@
   <action
       action_id="edit"
       category="object"
-      condition_expr=""
+      condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Event.xml
+++ b/plone/app/contenttypes/profiles/default/types/Event.xml
@@ -80,6 +80,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -89,6 +90,7 @@
       action_id="edit"
       category="object"
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/File.xml
+++ b/plone/app/contenttypes/profiles/default/types/File.xml
@@ -74,6 +74,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -83,6 +84,7 @@
       action_id="edit"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Folder.xml
+++ b/plone/app/contenttypes/profiles/default/types/Folder.xml
@@ -79,6 +79,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -88,6 +89,7 @@
       action_id="edit"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Image.xml
+++ b/plone/app/contenttypes/profiles/default/types/Image.xml
@@ -74,6 +74,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -83,6 +84,7 @@
       action_id="edit"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/Link.xml
+++ b/plone/app/contenttypes/profiles/default/types/Link.xml
@@ -72,6 +72,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -81,6 +82,7 @@
       action_id="edit"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/News_Item.xml
+++ b/plone/app/contenttypes/profiles/default/types/News_Item.xml
@@ -84,7 +84,7 @@
   <action
       action_id="edit"
       category="object"
-      condition_expr=""
+      condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">

--- a/plone/app/contenttypes/profiles/default/types/News_Item.xml
+++ b/plone/app/contenttypes/profiles/default/types/News_Item.xml
@@ -76,6 +76,7 @@
       action_id="view"
       category="object"
       condition_expr=""
+      i18n:attributes="title"
       title="View"
       url_expr="string:${object_url}"
       visible="True">
@@ -85,6 +86,7 @@
       action_id="edit"
       category="object"
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+      i18n:attributes="title"
       title="Edit"
       url_expr="string:${object_url}/edit"
       visible="True">


### PR DESCRIPTION
configure action edit urls to not be available, when item is locked - as it is recommended here: https://github.com/plone/plone.app.lockingbehavior/blob/master/README.rst

also, add ``i18n:attribute="title"`` to all action nodes.
i guess it is, but i'm not sure if it is necessary. it doesn't hurt at least....

when this is going to be answered, i can also add locking support to other types: 
https://github.com/plone/plone.app.contenttypes/issues/358

/cc @jensens @pbauer @vangheem 