### PR TITLE
remove dup path injection code in collections results method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ New features:
 
 Bug fixes:
 
+- Remove ``path`` index injection in "plone.collection" behaviors ``results`` method.
+  It is a duplicate.
+  Exactly the same is done already in the ``plone.app.querybuilder.querybuilder._makequery``,
+  which is called by above ``results`` method.
+  [jensens]
+
 - Select all migratable types in migration-form by default. Fixes #193.
   [pbauer]
 

--- a/plone/app/contenttypes/behaviors/collection.py
+++ b/plone/app/contenttypes/behaviors/collection.py
@@ -115,35 +115,8 @@ class Collection(object):
             sort_on = self.sort_on
         if not limit:
             limit = self.limit
-
-        query = self.query
-
-        # Handle INavigationRoot awareness as follows:
-        # - If query is None or empty then do nothing.
-        # - If query already contains a criteria for the index "path", then do
-        #   nothing, since plone.app.querybuilder takes care of this
-        #   already. (See the code of _path and _relativePath inside
-        #   p.a.querystring.queryparser to understand).
-        # - If query does not contain any criteria using the index "path", then
-        #   add a criteria to match everything under the path "/" (which will
-        #   be converted to the actual navigation root path by
-        #   p.a.querystring).
-        if query:
-            has_path_criteria = any(
-                (criteria['i'] == 'path')
-                for criteria in query
-            )
-            if not has_path_criteria:
-                # Make a copy of the query to avoid modifying it
-                query = list(self.query)
-                query.append({
-                    'i': 'path',
-                    'o': 'plone.app.querystring.operation.string.path',
-                    'v': '/',
-                })
-
         return querybuilder(
-            query=query, batch=batch, b_start=b_start, b_size=b_size,
+            query=self.query, batch=batch, b_start=b_start, b_size=b_size,
             sort_on=sort_on, sort_order=sort_order,
             limit=limit, brains=brains, custom_query=custom_query
         )


### PR DESCRIPTION
Remove ``path`` index injection in "plone.collection" behaviors ``results`` method.

It is a duplicate. Exactly the same is done already in the ``plone.app.querybuilder.querybuilder._makequery``,  which is called by above ``results`` method.

see https://github.com/plone/plone.app.querystring/blob/master/plone/app/querystring/querybuilder.py#L110-L120