### PR TITLE
Marked relative location criterion robot test as unstable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ New features:
 
 Bug fixes:
 
+- Marked relative location criterion robot test as unstable.
+  This needs further investigation, but must not block Plone development.
+  See issue https://github.com/plone/plone.app.contenttypes/issues/362
+  [maurits]
+
 - Remove ``path`` index injection in "plone.collection" behaviors ``results`` method.
   It is a duplicate.
   Exactly the same is done already in the ``plone.app.querybuilder.querybuilder._makequery``,

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -101,13 +101,21 @@ fill date field
   Click Element  xpath=//div[@data-fieldname="${fieldid}"]//div[contains(@class, 'picker__day')][contains(text(), "${day}")]
 
 I set the criteria ${type} in row ${number} to the option '${label}'
+  [Documentation]  A couple of times we shift the focus so the input sticks, and wait a bit,
+  ...              to make the test more stable.
   ${criteria_row} =  Convert to String  .querystring-criteria-wrapper:nth-child(${number})
   Wait until page contains element  css=${criteria_row} .querystring-criteria-${type} .select2-choice
   Click Element  css=${criteria_row} .querystring-criteria-${type} .select2-choice
+  Sleep  1.5
+  Focus  css=body
   Wait until element is visible  css=#select2-drop input
   Input Text  css=#select2-drop input  ${label}
+  Sleep  1.5
+  Focus  css=body
   Wait until element is visible  css=#select2-drop .select2-match
   Click Element  css=#select2-drop .select2-match
+  Sleep  1.5
+  Focus  css=body
 
 I set the criteria ${type} in row ${number} to the options '${label}'
   ${criteria_row} =  Convert to String  .querystring-criteria-wrapper:nth-child(${number})

--- a/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
@@ -22,6 +22,9 @@ Test Teardown  Close all browsers
 *** Test cases ***************************************************************
 
 Scenario: Test Relative Location Criterion
+    [Tags]  unstable
+    [Documentation]  This sometimes fails with:
+    ...              Element locator 'css=#select2-drop input' did not match any elements after 30 seconds
     Given I am logged in as site owner
       And a document   Document outside Folder
       And a folder 'my-folder' with a document 'Document within Folder'
@@ -32,8 +35,10 @@ Scenario: Test Relative Location Criterion
 
 
 Scenario: Test Absolute Location Criterion
-   [Tags]  unstable
-   [Documentation]  This sometimes fails with: Element locator 'css=#select2-drop input' did not match any elements after 30 seconds
+    [Tags]  unstable
+    [Documentation]  This sometimes fails with:
+    ...              Element locator 'css=#select2-drop input' did not match any elements after 30 seconds
+    ...              Or with: Element 'id=content' should not contain text 'Document outside Folder' but it did.
     Given I am logged in as site owner
       And a document   Document outside Folder
       And a folder 'my-folder' with a document 'Document within Folder'


### PR DESCRIPTION
This needs further investigation, but must not block Plone development.

I tried fixing it too in this pull request, and *maybe* it has become more stable. But locally on Plone 5.1 with Firefox 46.0.1 I still see sometimes a failure, sometimes a success.
See for example http://jenkins.plone.org/job/plone-5.1-python-2.7-robot/671/robot/

Issue for fixing this and another unstable test: https://github.com/plone/plone.app.contenttypes/issues/362