### PR TITLE
Fix Mimetype icon path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New features:
 
 Bug fixes:
 
+- Fix Mimetype icon path. With the removal of the skins folder in
+  https://github.com/plone/Products.MimetypesRegistry/pull/8/commits/61acf8327e5c844bff9e5c5676170aaf0ee2c323
+  we need the full resourcepath now
+  [agitator]
+
 - Show message for editors when viewing Link.
   Fixes `issue 375 <https://github.com/plone/plone.app.contenttypes/issues/375>`_.
   [maurits]

--- a/plone/app/contenttypes/browser/utils.py
+++ b/plone/app/contenttypes/browser/utils.py
@@ -37,7 +37,8 @@ class Utils(BrowserView):
         if content_file.filename:
             mime.append(mtr.lookupExtension(content_file.filename))
         mime.append(mtr.lookup('application/octet-stream')[0])
-        icon_paths = [m.icon_path for m in mime if hasattr(m, 'icon_path')]
+        icon_paths = ['++resource++mimetype.icons/' + m.icon_path
+                      for m in mime if hasattr(m, 'icon_path')]
         if icon_paths:
             return icon_paths[0]
 


### PR DESCRIPTION
with the removal of the skins folder in https://github.com/plone/Products.MimetypesRegistry/pull/8/commits/61acf8327e5c844bff9e5c5676170aaf0ee2c323 we need the full resourcepath now