### PR TITLE
String needs to be unicode when format parameter is unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use unicode string when .format() parameter is unicode for the field migrator
+  [frapell]
 
 
 1.2.19 (2016-12-02)

--- a/plone/app/contenttypes/migration/field_migrators.py
+++ b/plone/app/contenttypes/migration/field_migrators.py
@@ -92,7 +92,7 @@ def migrate_imagefield(src_obj, dst_obj, src_fieldname, dst_fieldname):
                 ('{0}_caption'.format(dst_fieldname)),
                 safe_unicode(caption_field.get(src_obj)))
 
-    logger.info('Migrating image {0}'.format(filename))
+    logger.info(u'Migrating image {0}'.format(filename))
 
 
 def migrate_blobimagefield(src_obj, dst_obj, src_fieldname, dst_fieldname):
@@ -122,7 +122,7 @@ def migrate_blobimagefield(src_obj, dst_obj, src_fieldname, dst_fieldname):
                 ('{0}_caption'.format(dst_fieldname)),
                 safe_unicode(old_image_caption))
 
-    logger.info('Migrating image {0}'.format(filename))
+    logger.info(u'Migrating image {0}'.format(filename))
 
 
 def migrate_filefield(src_obj, dst_obj, src_fieldname, dst_fieldname):
@@ -142,7 +142,7 @@ def migrate_filefield(src_obj, dst_obj, src_fieldname, dst_fieldname):
         data=old_file_data,
         filename=filename)
     setattr(dst_obj, dst_fieldname, namedblobfile)
-    logger.info('Migrating file {0}'.format(filename))
+    logger.info(u'Migrating file {0}'.format(filename))
 
 
 def migrate_datetimefield(src_obj, dst_obj, src_fieldname, dst_fieldname):


### PR DESCRIPTION
I got UnicodeEncodeError when migrating unicode filenames. This is the error:

```
>>> var = u'\xf3'
>>> print var
ó
>>> "%s"%var
u'\xf3'
>>> "{0}".format(var)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 0: ordinal not in range(128)
>>> u"{0}".format(var)
u'\xf3'
>>> print u"{0}".format(var)
ó
```
