### PR TITLE
Optimize listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Only wake up event objects (this is needed for a the date math) in listings
+  [tomgross]
 
 
 1.2.21 (2017-02-05)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -82,17 +82,3 @@ eggs = createcoverage
 [versions]
 # this tells buildout to _not_ use a relased version of this package
 plone.app.contenttypes =
-# Temporarily until next Plone version is out:
-plone.app.querystring = 1.3.4
-
-setuptools = 18.2
-zc.buildout = 2.4.1
-zc.recipe.egg = 2.0.2
-flake8 = 2.3.0
-i18ndude = 3.4.0
-robotframework = 2.8.4
-robotframework-ride = 1.3
-robotframework-selenium2library = 1.6.0
-robotsuite = 1.6.1
-selenium = 2.46.0
-coverage = 3.7.1

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -7,6 +7,7 @@ from plone.app.contenttypes.interfaces import IImage
 from plone.event.interfaces import IEvent
 from plone.memoize.view import memoize
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.PloneBatch import Batch
 from Products.CMFPlone.utils import safe_callable
 from Products.Five import BrowserView
@@ -35,6 +36,8 @@ class FolderView(BrowserView):
             (context, request), name=u'plone_portal_state')
         self.pas_member = getMultiAdapter(
             (context, request), name=u'pas_member')
+        self.portal_catalog = getToolByName(aq_inner(self.context),
+                                            'portal_catalog')
 
         self.text_class = None
 
@@ -165,9 +168,10 @@ class FolderView(BrowserView):
         }
 
     def is_event(self, obj):
-        if getattr(obj, 'getObject', False):
-            obj = obj.getObject()
-        return IEvent.providedBy(obj)
+        """ Check if an obj (which is a brain in a listing) is an event """
+        rid = obj.getRID()
+        return IEvent.__identifier__ in \
+            self.portal_catalog.getIndexDataForRID(rid)['object_provides']
 
     def formatted_date(self, item):
         provider = getMultiAdapter(

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -23,7 +23,7 @@
       <tal:listing condition="batch">
         <div class="entries" metal:define-slot="entries">
           <tal:repeat repeat="item batch" metal:define-macro="entries">
-            <tal:block tal:define="obj item/getObject;
+            <tal:block tal:define="
                 item_url item/getURL;
                 item_id item/getId;
                 item_title item/Title;
@@ -36,7 +36,7 @@
                 item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
                 item_creator item/Creator;
                 item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;
-                item_is_event python:view.is_event(obj);
+                item_is_event python:view.is_event(item);
                 item_has_image python:item.getIcon">
               <metal:block define-slot="entry">
                 <article class="entry">
@@ -58,7 +58,8 @@
                     <metal:block metal:define-macro="document_byline">
                       <div class="documentByLine">
                         <tal:event condition="item_is_event">
-                          <tal:date tal:replace="structure python:view.formatted_date(obj)"/>
+                          <tal:date  tal:define="obj item/getObject"
+			             tal:replace="structure python:view.formatted_date(obj)"/>
                           <span tal:condition="item/location" i18n:translate="label_event_byline_location">&mdash;
                             <span tal:content="string:${item/location}" class="location" i18n:name="location">Oslo</span>,
                           </span>


### PR DESCRIPTION
This PR optimizes the default (folder) listing templates.
Previously all objects were awakend from the catalog. Now this is only done for events. It seems to be needed for some date math.