### PR TITLE
Prevent custom folder migration from failing

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes:
   (rather than of that of the raw) value in plaintext conversion. Fixes #357.
   [petri]
 
+- Add condition so custom folder migration does not fail if there is not
+  an 'excludeFromNav'
+  [cdw9]
+
 
 1.1.1 (2016-06-06)
 ------------------

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -159,7 +159,8 @@ class ATCTFolderMigrator(CMFFolderMigrator):
 
     def migrate_atctmetadata(self):
         field = self.old.getField('excludeFromNav')
-        self.new.exclude_from_nav = field.get(self.old)
+        if field:
+            self.new.exclude_from_nav = field.get(self.old)
 
     def migrate_custom(self):
         """Get all ICustomMigrator registered migrators and run the migration.


### PR DESCRIPTION
Add condition so custom folder migration does not fail if there is not an 'excludeFromNav'