### PR TITLE
Prevent custom folder migration from failing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Only wake up event objects (this is needed for a the date math) in listings
   [tomgross]
 
+- Add condition so custom folder migration does not fail if there is not
+  an 'excludeFromNav'
+  [cdw9]
+
 
 1.2.21 (2017-02-05)
 -------------------

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -162,7 +162,8 @@ class ATCTFolderMigrator(CMFFolderMigrator):
 
     def migrate_atctmetadata(self):
         field = self.old.getField('excludeFromNav')
-        self.new.exclude_from_nav = field.get(self.old)
+        if field:
+            self.new.exclude_from_nav = field.get(self.old)
 
     def migrate_custom(self):
         """Get all ICustomMigrator registered migrators and run the migration.


### PR DESCRIPTION
Add condition so custom folder migration does not fail if there is not an 'excludeFromNav'

Same as pull request 387, but this is for the latest version