### PR TITLE
Fix issue where contentFilter could not be read from request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix issue where contentFilter could not be read from request
+  [datakurre]
 
 
 1.3.0 (2017-03-27)

--- a/plone/app/contenttypes/browser/collection.py
+++ b/plone/app/contenttypes/browser/collection.py
@@ -36,7 +36,7 @@ class CollectionView(FolderView):
                 sequence.
         """
         # Extra filter
-        contentFilter = self.request.get('contentFilter', {})
+        contentFilter = dict(self.request.get('contentFilter', {}))
         contentFilter.update(kwargs.get('contentFilter', {}))
         kwargs.setdefault('custom_query', contentFilter)
         kwargs.setdefault('batch', True)


### PR DESCRIPTION
Traditionally it has been possible to customize collection search with contentFilter request parameter. This is based on ZServer HTTPRequest demarshalling query string into contentFilter dictionary. For example:

        contentFilter.portal_type:list:record=Image

would be parsed into request.form['contentFilter'] as

        {"portal_type": ["Image"]}

and would restrict collection to only display images (unless content_type criteria was already defined in collection).

This almost worked already, but didn't because HTTPRequest does seem to return some kind of dict like wrapper instead of real dictionary, resulting ``update`` method being missing attribute. This is fixed by this pull by enforcing contentFilter read from request to be real dictionary.