### PR TITLE
Fixed Mimetype icon path. [1.2.x, Plone 5.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New features:
 
 Bug fixes:
 
+- Fixed Mimetype icon path. Version 1.2.19 introduced a change to fit
+  Products.MimetypesRegistry 2.1, but Plone 5.0 should remain on 2.0.x.
+  Fixes `issue 1997 <https://github.com/plone/Products.CMFPlone/issues/1997>`_.
+  [maurits]
+
 - Avoid failure during migration if relation is broken.
   [cedricmessiant]
 

--- a/plone/app/contenttypes/browser/utils.py
+++ b/plone/app/contenttypes/browser/utils.py
@@ -37,8 +37,7 @@ class Utils(BrowserView):
         if content_file.filename:
             mime.append(mtr.lookupExtension(content_file.filename))
         mime.append(mtr.lookup('application/octet-stream')[0])
-        icon_paths = ['++resource++mimetype.icons/' + m.icon_path
-                      for m in mime if hasattr(m, 'icon_path')]
+        icon_paths = [m.icon_path for m in mime if hasattr(m, 'icon_path')]
         if icon_paths:
             return icon_paths[0]
 


### PR DESCRIPTION
Version 1.2.19 introduced a change to fit Products.MimetypesRegistry 2.1, but Plone 5.0 should remain on 2.0.x.
Fixes https://github.com/plone/Products.CMFPlone/issues/1997.

Revert "with the removal of the skins folder in https://github.com/plone/Products.MimetypesRegistry/pull/8/commits/61acf8327e5c844bff9e5c5676170aaf0ee2c323 we need the full resourcepath now"
This reverts commit 292aefd647a67d6d0767aba39a687845fab00a76.