### PR TITLE
Make content_type a property and do not fail if image/file is None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 New features:
 
-- new metadata catalog columń MimeType
+- New metadata catalog column MimeType
   https://github.com/plone/Products.CMFPlone/issues/1995
   [fgrcon]
 

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -97,10 +97,10 @@ class File(Item):
         return response
 
     def get_size(self):
-        return self.file.size
+        return getattr(self.file, 'size', None)
 
     def content_type(self):
-        return self.file.contentType
+        return getattr(self.file, 'contentType', None)
 
 
 @implementer(IFolder)
@@ -131,10 +131,10 @@ class Image(Item):
         return response
 
     def get_size(self):
-        return self.image.size
+        return getattr(self.image, 'size', None)
 
     def content_type(self):
-        return self.image.contentType
+        return getattr(self.image, 'contentType', None)
 
 
 @implementer(ILink)


### PR DESCRIPTION
@jensens @fgrcon i had to keep the ``content_type`` as method, as this was added here a year ago:
https://github.com/plone/plone.app.contenttypes/commit/1b6c75dae22cee9ad13b99fb013cd02189ff2d9a

I thought, that was done with latest @fgrcon PR, but it wasn't.

however, with the getattr call, the plone.app.upgrade step shouldn't fail anymore.