### PR TITLE
Fixed two failing unit tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New features:
 
 Bug fixes:
 
+- Fixed two failing unit tests.  [maurits]
+
 - Made sure the text field of Collections is searchable.
   `Issue 406 <https://github.com/plone/plone.app.contenttypes/issues/406>`_.
   [maurits]

--- a/plone/app/contenttypes/tests/test_document.py
+++ b/plone/app/contenttypes/tests/test_document.py
@@ -72,7 +72,7 @@ class DocumentIntegrationTest(unittest.TestCase):
         self.request.set('URL', document.absolute_url())
         self.request.set('ACTUAL_URL', document.absolute_url())
         alsoProvides(self.request, IPloneFormLayer)
-        view = document.restrictedTraverse('@@view')
+        view = document.restrictedTraverse('@@document_view')
         self.assertEqual(view.request.response.status, 200)
         output = view()
         self.assertTrue(output)

--- a/plone/app/contenttypes/tests/test_news_item.py
+++ b/plone/app/contenttypes/tests/test_news_item.py
@@ -85,7 +85,7 @@ class NewsItemIntegrationTest(unittest.TestCase):
         )
         self.request.set('URL', news_item.absolute_url())
         self.request.set('ACTUAL_URL', news_item.absolute_url())
-        view = news_item.restrictedTraverse('@@view')
+        view = news_item.restrictedTraverse('newsitem_view')
 
         self.assertTrue(view())
         self.assertEqual(view.request.response.status, 200)


### PR DESCRIPTION
Calling @@view on a document or news item does not correctly show the body text.
You get this: `RichTextValue object. (Did you mean .raw or .output?)`

This is because @@view uses a standard item.pt template from plone.app.dexterity.
Instead, these tests should use the default browser views defined in the profile.
Then the text is properly displayed.