### PR TITLE
Made sure the text field of Collections is searchable. [1.2.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,13 @@ New features:
 
 Bug fixes:
 
+- Made sure the text field of Collections is searchable.
+  `Issue 406 <https://github.com/plone/plone.app.contenttypes/issues/406>`_.
+  [maurits]
+
 - Fix flaky test in test_indexes.
   [thet]
+
 
 1.2.23 (2017-05-09)
 -------------------

--- a/plone/app/contenttypes/indexers.py
+++ b/plone/app/contenttypes/indexers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from logging import getLogger
 from plone.app.contenttypes.behaviors.richtext import IRichText
+from plone.app.contenttypes.interfaces import ICollection
 from plone.app.contenttypes.interfaces import IDocument
 from plone.app.contenttypes.interfaces import IFile
 from plone.app.contenttypes.interfaces import IFolder
@@ -69,6 +70,11 @@ def SearchableText_news(obj):
 
 @indexer(IDocument)
 def SearchableText_document(obj):
+    return _unicode_save_string_concat(SearchableText(obj))
+
+
+@indexer(ICollection)
+def SearchableText_collection(obj):
     return _unicode_save_string_concat(SearchableText(obj))
 
 

--- a/plone/app/contenttypes/indexers.zcml
+++ b/plone/app/contenttypes/indexers.zcml
@@ -5,6 +5,7 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="plone">
 
+  <adapter name="SearchableText" factory=".indexers.SearchableText_collection" />
   <adapter name="SearchableText" factory=".indexers.SearchableText_document" />
   <adapter name="SearchableText" factory=".indexers.SearchableText_file" />
   <adapter name="SearchableText" factory=".indexers.SearchableText_folder" />

--- a/plone/app/contenttypes/profiles/default/metadata.xml
+++ b/plone/app/contenttypes/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1104</version>
+ <version>1105</version>
  <dependencies>
   <dependency>profile-plone.app.dexterity:default</dependency>
   <dependency>profile-plone.app.event:default</dependency>

--- a/plone/app/contenttypes/tests/test_indexes.py
+++ b/plone/app/contenttypes/tests/test_indexes.py
@@ -40,6 +40,10 @@ class CatalogIntegrationTest(unittest.TestCase):
             'file'
         )
         self.folder.invokeFactory(
+            'Collection',
+            'collection'
+        )
+        self.folder.invokeFactory(
             'Folder',
             'folder'
         )
@@ -48,6 +52,8 @@ class CatalogIntegrationTest(unittest.TestCase):
         self.link = self.folder.link
         self.image = self.folder.image
         self.file = self.folder.file
+        self.collection = self.folder.collection
+        # Note: this changes self.folder.
         self.folder = self.folder.folder
         self.catalog = getToolByName(self.portal, 'portal_catalog')
 
@@ -143,12 +149,18 @@ class CatalogIntegrationTest(unittest.TestCase):
             'text/plain',
             'text/html'
         )
+        self.collection.text = RichTextValue(
+            u'Lorem ipsum',
+            'text/plain',
+            'text/html'
+        )
         self.document.reindexObject()
         self.news_item.reindexObject()
+        self.collection.reindexObject()
         brains = self.catalog.searchResults(dict(
             SearchableText=u'Lorem ipsum',
         ))
-        self.assertEqual(len(brains), 2)
+        self.assertEqual(len(brains), 3)
 
         paths = [it.getPath() for it in brains]
         self.assertTrue(
@@ -157,6 +169,38 @@ class CatalogIntegrationTest(unittest.TestCase):
         self.assertTrue(
             '/plone/folder/document' in paths
         )
+        self.assertTrue(
+            '/plone/folder/collection' in paths
+        )
+
+    def test_collection_text_in_searchable_text_index_after_upgrade(self):
+        # At first, the text field of Collections did not end up
+        # in the SearchableText index.
+        # To mimic this, we reindex the object and afterwards set the text.
+        self.collection.reindexObject()
+        # Check that nothing is found yet.
+        # This is needed to force a flush of the indexing queue.
+        brains = self.catalog.searchResults(dict(
+            SearchableText=u'Lorem ipsum',
+        ))
+        self.assertEqual(len(brains), 0)
+        self.collection.text = RichTextValue(
+            u'Lorem ipsum',
+            'text/plain',
+            'text/html'
+        )
+        brains = self.catalog.searchResults(dict(
+            SearchableText=u'Lorem ipsum',
+        ))
+        self.assertEqual(len(brains), 0)
+        # Now we apply the upgrade.
+        from plone.app.contenttypes.upgrades import searchabletext_collections
+        searchabletext_collections(self.portal.portal_setup)
+        brains = self.catalog.searchResults(dict(
+            SearchableText=u'Lorem ipsum',
+        ))
+        self.assertEqual(len(brains), 1)
+        self.assertEqual(brains[0].getPath(), '/plone/folder/collection')
 
     def test_html_stripped_searchable_text_index(self):
         """Ensure, html tags are stripped out from the content and not indexed.

--- a/plone/app/contenttypes/upgrades.py
+++ b/plone/app/contenttypes/upgrades.py
@@ -209,3 +209,12 @@ def use_new_view_names(context, types_to_fix=None):  # noqa
             _fixup(obj, LISTING_VIEW_MAPPING)
         if portal_type == 'Plone Site':
             _fixup(context, LISTING_VIEW_MAPPING)
+
+
+def searchabletext_collections(context):
+    """Reindex Collections for SearchableText."""
+    catalog = getToolByName(context, 'portal_catalog')
+    search = catalog.unrestrictedSearchResults
+    for brain in search(portal_type='Collection'):
+        obj = brain.getObject()
+        obj.reindexObject(idxs=['SearchableText'])

--- a/plone/app/contenttypes/upgrades.zcml
+++ b/plone/app/contenttypes/upgrades.zcml
@@ -71,4 +71,12 @@
       handler=".upgrades.use_new_view_names"
       />
 
+  <genericsetup:upgradeStep
+      source="1104"
+      destination="1105"
+      title="Reindex SearchableText for Collections"
+      profile="plone.app.contenttypes:default"
+      handler=".upgrades.searchabletext_collections"
+      />
+
 </configure>


### PR DESCRIPTION
Includes upgrade step to reindex the SearchableText index for existing Collections.

Fixes https://github.com/plone/plone.app.contenttypes/issues/406 for Plone 5.0.