### PR TITLE
Use original raw text and mimetype when indexing rich text. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ New features:
 
 Bug fixes:
 
+- Use original raw text and mimetype when indexing rich text.
+  This avoids a double transform (raw source to output mimetype to plain text).
+  Includes a reindex of the SearchableText index for Collections, Documents and News Items.
+  `Issue 2066 <https://github.com/plone/Products.CMFPlone/issues/2066>`_.
+  [maurits]
+
 - Remove Language='all' from migration-query since it was removed from p.a.multilingual
   [pbauer]
 

--- a/plone/app/contenttypes/indexers.py
+++ b/plone/app/contenttypes/indexers.py
@@ -46,9 +46,12 @@ def SearchableText(obj):
         textvalue = richtext.text
         if IRichTextValue.providedBy(textvalue):
             transforms = getToolByName(obj, 'portal_transforms')
+            # Before you think about switching raw/output
+            # or mimeType/outputMimeType, first read
+            # https://github.com/plone/Products.CMFPlone/issues/2066
             text = transforms.convertTo(
                 'text/plain',
-                safe_unicode(textvalue.output).encode('utf8'),
+                safe_unicode(textvalue.raw).encode('utf-8'),
                 mimetype=textvalue.mimeType,
             ).getData().strip()
 

--- a/plone/app/contenttypes/profiles/default/metadata.xml
+++ b/plone/app/contenttypes/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1105</version>
+ <version>1106</version>
  <dependencies>
   <dependency>profile-plone.app.dexterity:default</dependency>
   <dependency>profile-plone.app.event:default</dependency>

--- a/plone/app/contenttypes/tests/test_indexes.py
+++ b/plone/app/contenttypes/tests/test_indexes.py
@@ -220,6 +220,29 @@ class CatalogIntegrationTest(unittest.TestCase):
         self.assertEqual(index_data['SearchableText'].count('p'), 0)
         self.assertEqual(index_data['SearchableText'].count('b'), 0)
 
+    def test_raw_text_searchable_text_index(self):
+        """Ensure that raw text is used, instead of output.
+
+        It makes no sense to transform raw text to the output mimetype,
+        and then transform it again to plain text.
+        Note that this does mean that javascript may get in the
+        searchable text, but you will usually have a hard time setting it.
+        """
+        self.document.text = RichTextValue(
+            u"""<script type="text/javascript">alert('Lorem ipsum')</script>""",
+            mimeType='text/html',
+            outputMimeType='text/x-html-safe'
+        )
+        self.document.reindexObject()
+        brains = self.catalog.searchResults(dict(
+            SearchableText=u'Lorem ipsum',
+        ))
+        self.assertEqual(len(brains), 1)
+        rid = brains[0].getRID()
+        index_data = self.catalog.getIndexDataForRID(rid)
+        self.assertEqual(index_data['SearchableText'].count('script'), 0)
+        self.assertEqual(index_data['SearchableText'].count('text'), 0)
+
     def test_file_fulltext_in_searchable_text_index_string(self):
         from plone.namedfile.file import NamedBlobFile
         data = ('Lorem ipsum. Köln <!-- ...oder München, das ist hier die '

--- a/plone/app/contenttypes/upgrades.py
+++ b/plone/app/contenttypes/upgrades.py
@@ -218,3 +218,20 @@ def searchabletext_collections(context):
     for brain in search(portal_type='Collection'):
         obj = brain.getObject()
         obj.reindexObject(idxs=['SearchableText'])
+
+
+def searchabletext_richtext(context):
+    """Reindex rich text types for SearchableText.
+
+    Our SearchableText indexer has been going back and forth between
+    taking the raw text or the output, and using the original mimetype
+    or the output mimetype.  We are on the third combination now
+    (original raw source with original mimetype) so it is time to reindex.
+
+    See https://github.com/plone/Products.CMFPlone/issues/2066
+    """
+    catalog = getToolByName(context, 'portal_catalog')
+    search = catalog.unrestrictedSearchResults
+    for brain in search(portal_type=['Collection', 'Document', 'News Item']):
+        obj = brain.getObject()
+        obj.reindexObject(idxs=['SearchableText'])

--- a/plone/app/contenttypes/upgrades.zcml
+++ b/plone/app/contenttypes/upgrades.zcml
@@ -79,4 +79,12 @@
       handler=".upgrades.searchabletext_collections"
       />
 
+  <genericsetup:upgradeStep
+      source="1105"
+      destination="1106"
+      title="Reindex SearchableText for all rich text types"
+      profile="plone.app.contenttypes:default"
+      handler=".upgrades.searchabletext_richtext"
+      />
+
 </configure>


### PR DESCRIPTION
This avoids a double transform (raw source to output mimetype to plain text).
Includes a reindex of the SearchableText index for Collections, Documents and News Items.

Issue https://github.com/plone/Products.CMFPlone/issues/2066

Should be done for other branches too, but let's first see if this gets approved.