### PR TITLE
Add patch of catalog optimization during migrations to DX 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Bug fixes:
   definitions for the content types that have extra field defined on top of the
   behavior composition. Otherwise no translations can be picked up.
   [fredvd]
+- Disable queuing of indexing-operations (PLIP https://github.com/plone/Products.CMFPlone/issues/1343)
+  during migration to Dexterity to prevent catalog-errors.
+  [pbauer]
 
 - Use original raw text and mimetype when indexing rich text.
   This avoids a double transform (raw source to output mimetype to plain text).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Disable queuing of indexing-operations (PLIP https://github.com/plone/Products.CMFPlone/issues/1343)
+  during migration to Dexterity to prevent catalog-errors.
+  [pbauer]
 
 
 1.4.2 (2017-08-27)
@@ -34,9 +36,6 @@ Bug fixes:
   definitions for the content types that have extra field defined on top of the
   behavior composition. Otherwise no translations can be picked up.
   [fredvd]
-- Disable queuing of indexing-operations (PLIP https://github.com/plone/Products.CMFPlone/issues/1343)
-  during migration to Dexterity to prevent catalog-errors.
-  [pbauer]
 
 - Use original raw text and mimetype when indexing rich text.
   This avoids a double transform (raw source to output mimetype to plain text).

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -17,6 +17,8 @@ from plone.app.contenttypes.migration.field_migrators import migrate_filefield
 from plone.app.contenttypes.migration.field_migrators import migrate_imagefield
 from plone.app.contenttypes.migration.field_migrators import migrate_richtextfield  # noqa
 from plone.app.contenttypes.migration.field_migrators import migrate_simplefield  # noqa
+from plone.app.contenttypes.migration.patches import patch_before_migration
+from plone.app.contenttypes.migration.patches import undo_patch_after_migration
 from plone.app.contenttypes.migration.utils import copy_contentrules
 from plone.app.contenttypes.migration.utils import migrate_leadimage
 from plone.app.contenttypes.migration.utils import migrate_portlets
@@ -476,6 +478,9 @@ def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
     """
     portal = getSite()
 
+    # Patch various things that make migration harder
+    link_integrity, queue_indexing = patch_before_migration()
+
     # if the type still exists get the src_meta_type from the portal_type
     portal_types = getToolByName(portal, 'portal_types')
     fti = portal_types.get(src_type, None)
@@ -513,6 +518,7 @@ def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
                                     fields_mapping=fields_mapping,
                                     is_folderish=is_folderish,
                                     dry_run=dry_run)
+    walker_infos = None
     if migrator:
         migrator.src_meta_type = src_meta_type
         migrator.dst_meta_type = ''
@@ -534,4 +540,8 @@ def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
             logger.error(error.get('message'))
         if dry_run:
             transaction.abort()
-        return walker_infos
+
+    # Revert to the original state
+    undo_patch_after_migration(link_integrity, queue_indexing)
+
+    return walker_infos

--- a/plone/app/contenttypes/migration/patches.py
+++ b/plone/app/contenttypes/migration/patches.py
@@ -2,7 +2,25 @@
 """Patches used for migrations. These patches are applied before and removed
 after running the migration.
 """
+from plone.dexterity.content import DexterityContent
+from plone.registry.interfaces import IRegistry
+from Products.Archetypes.ExtensibleMetadata import ExtensibleMetadata
+from Products.CMFCore.interfaces import IPropertiesTool
+from Products.CMFPlone.DublinCore import DefaultDublinCoreImpl
+from Products.CMFPlone.interfaces import IEditingSchema
+from Products.contentmigration.utils import patch
+from Products.contentmigration.utils import undoPatch
 from Products.PluginIndexes.common.UnIndex import _marker
+from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
+from zope.component import getUtility
+from zope.component import queryUtility
+
+import os
+
+
+def pass_fn(*args, **kwargs):
+    """Empty function used for patching."""
+    pass
 
 
 # Prevent UUID Error-Messages when migrating folders.
@@ -18,3 +36,85 @@ def patched_insertForwardIndexEntry(self, entry, documentId):
     if old_docid is _marker:
         self._index[entry] = documentId
         self._length.change(1)
+
+
+def patch_before_migration():
+    """Patch various things that make migration harder."""
+    # Switch linkintegrity off
+    ptool = queryUtility(IPropertiesTool)
+    site_props = getattr(ptool, 'site_properties', None)
+    if site_props and site_props.hasProperty(
+            'enable_link_integrity_checks'):
+        link_integrity = site_props.getProperty(
+            'enable_link_integrity_checks', False)
+        site_props.manage_changeProperties(
+            enable_link_integrity_checks=False)
+    else:
+        # Plone 5
+        registry = getUtility(IRegistry)
+        editing_settings = registry.forInterface(
+            IEditingSchema, prefix='plone')
+        link_integrity = editing_settings.enable_link_integrity_checks
+        editing_settings.enable_link_integrity_checks = False
+
+    # Patch notifyModified to prevent setModificationDate() on changes
+    # notifyModified lives in several places and is also used on folders
+    # when their content changes.
+    # So when we migrate Documents before Folders the folders
+    # ModifiedDate gets changed
+    PATCH_NOTIFY = [
+        DexterityContent,
+        DefaultDublinCoreImpl,
+        ExtensibleMetadata
+    ]
+    for klass in PATCH_NOTIFY:
+        patch(klass, 'notifyModified', pass_fn)
+
+    # Disable queueing of indexing/reindexing/unindexing
+    queue_indexing = os.environ.get('CATALOG_OPTIMIZATION_DISABLED', None)
+    os.environ['CATALOG_OPTIMIZATION_DISABLED'] = '1'
+
+    # Patch UUIDIndex
+    patch(
+        UUIDIndex,
+        'insertForwardIndexEntry',
+        patched_insertForwardIndexEntry)
+
+    return link_integrity, queue_indexing
+
+
+def undo_patch_after_migration(link_integrity=True, queue_indexing=None):
+    """Revert to the original state."""
+
+    # Switch linkintegrity back to what it was before migrating
+    ptool = queryUtility(IPropertiesTool)
+    site_props = getattr(ptool, 'site_properties', None)
+    if site_props and site_props.hasProperty(
+            'enable_link_integrity_checks'):
+        site_props.manage_changeProperties(
+            enable_link_integrity_checks=link_integrity
+        )
+    else:
+        # Plone 5
+        registry = getUtility(IRegistry)
+        editing_settings = registry.forInterface(
+            IEditingSchema, prefix='plone')
+        editing_settings.enable_link_integrity_checks = link_integrity
+
+    # Switch on setModificationDate on changes
+    PATCH_NOTIFY = [
+        DexterityContent,
+        DefaultDublinCoreImpl,
+        ExtensibleMetadata
+    ]
+    for klass in PATCH_NOTIFY:
+        undoPatch(klass, 'notifyModified')
+
+    # Reset queueing of indexing/reindexing/unindexing
+    if queue_indexing is not None:
+        os.environ['CATALOG_OPTIMIZATION_DISABLED'] = queue_indexing
+    else:
+        del os.environ['CATALOG_OPTIMIZATION_DISABLED']
+
+    # Unpatch UUIDIndex
+    undoPatch(UUIDIndex, 'insertForwardIndexEntry')


### PR DESCRIPTION
This disables queuing of indexing-operations during migration to Dexterity to prevent catalog-errors. 

Here is example traceback:

    (...)
      Module plone.app.contenttypes.migration.browser, line 227, in __call__
      Module plone.app.contenttypes.migration.topics, line 702, in migrate_topics
      Module Products.contentmigration.basemigrator.walker, line 144, in go
      Module Products.contentmigration.basemigrator.walker, line 177, in migrate
      Module Products.contentmigration.walker, line 64, in walk
      Module Products.ZCatalog.CatalogBrains, line 93, in getObject
      Module Products.ZCatalog.CatalogBrains, line 57, in getPath
      Module Products.ZCatalog.ZCatalog, line 518, in getpath
    KeyError: 487546660

Also: 

* move all patches to a separate method
* use the same patches for custom migrations