### PR TITLE
fix retrieving of portal object in setuphandlers

### DIFF
--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -326,7 +326,7 @@ def configure_members_folder(portal, target_language):
 
 def step_import_content(context):
     """Create default content."""
-    portal = context.__parent__
+    portal = getSite()
     target_language, is_combined_language, locale = _get_locales_info(portal)
     create_frontpage(portal, target_language)
     create_news_topic(portal, target_language)
@@ -335,7 +335,7 @@ def step_import_content(context):
 
 
 def step_setup_various(context):
-    portal = context.__parent__
+    portal = getSite()
     target_language, is_combined_language, locale = _get_locales_info(portal)
     _setup_calendar(portal, locale)
     _setup_visible_ids(portal, target_language, locale)


### PR DESCRIPTION
When importing my integration profile in the ZMI, i get the following error - this PR fixes it for me. I don't know, if there are situations, where ```getSite``` fails... I don't think it would.

```
2017-09-29 23:15:27 ERROR Zope.SiteErrorLog 1506719727.480.134533008393 http://localhost:8080/Plone/portal_setup/manage_importAllSteps
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 579, in manage_importAllSteps
  Module Products.GenericSetup.tool, line 388, in runAllImportStepsFromProfile
   - __traceback_info__: profile-bda.aaf.site:default
  Module Products.GenericSetup.tool, line 1433, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1245, in _doRunImportStep
   - __traceback_info__: plone.app.contenttypes
  Module plone.app.contenttypes.setuphandlers, line 338, in step_setup_various
AttributeError: 'DirectoryImportContext' object has no attribute '__parent__'
^C2017-09-29 23:15:42 INFO SignalHandler Caught signal SIGINT
2017-09-29 23:15:42 INFO Z2 Shutting down
```