### PR TITLE
Do not use a default value in the form of ``http://`` for the link.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ New features:
 
 Bug fixes:
 
+- Do not use a default value in the form of ``http://`` for the link.
+  The new link widget resolves that to the portal root object.
+  Also, it's not a valid URL.
+  Fixes: https://github.com/plone/Products.CMFPlone/issues/2163
+  [thet]
+
 - Remove obsolete HAS_MULTILINGUAL from utils.
   [pbauer]
 

--- a/plone/app/contenttypes/schema/link.xml
+++ b/plone/app/contenttypes/schema/link.xml
@@ -5,7 +5,6 @@
        i18n:domain="plone">
     <schema>
       <field name="remoteUrl" type="zope.schema.TextLine" form:widget="plone.app.z3cform.widget.LinkFieldWidget">
-        <default>http://</default>
         <description i18n:translate="description_linktype_url">The link is used almost verbatim, relative links become absolute and the strings "${navigation_root_url}" and "${portal_url}" get replaced with the real navigation_root_url or portal_url. If in doubt which one to use, please use navigation_root_url.
         </description>
         <title i18n:translate="">URL</title>

--- a/plone/app/contenttypes/tests/test_link.py
+++ b/plone/app/contenttypes/tests/test_link.py
@@ -269,6 +269,8 @@ class LinkFunctionalTest(unittest.TestCase):
             .value = 'This is my link.'
         self.browser.getControl(name='form.widgets.IShortName.id')\
             .value = 'my-special-link'
+        self.browser.getControl(name='form.widgets.remoteUrl.external')\
+            .value = 'https://plone.org'
         self.browser.getControl('Save').click()
 
         self.assertTrue(self.browser.url.endswith('my-special-link/view'))


### PR DESCRIPTION
Otherwise, the new link widget resolves that to the portal root object.
Also, it's not a valid URL.
Fixes: https://github.com/plone/Products.CMFPlone/issues/2163

The default value also allows that the required field passes the requirement-check - the Link form can just submitted without entering a valid URL.
Instead of the default value, the other PR 76 from plone.app.z3cform adds placeholders for email and external link.

Merge together:
https://github.com/plone/plone.app.contenttypes/pull/431
https://github.com/plone/plone.app.z3cform/pull/76