### PR TITLE
Remove last use of atcontenttypes translation domain.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove last use of ``atcontenttypes`` translation domain.
+  Fixes `issue 37 <https://github.com/plone/plone.app.contenttypes/issues/37>`_.
+  [maurits]
 
 
 1.4.5 (2017-10-06)

--- a/plone/app/contenttypes/behaviors/tableofcontents.py
+++ b/plone/app/contenttypes/behaviors/tableofcontents.py
@@ -6,7 +6,7 @@ from zope.i18nmessageid import MessageFactory
 from zope.interface import provider
 
 
-_ = MessageFactory('atcontenttypes')
+_ = MessageFactory('plone')
 
 
 @provider(IFormFieldProvider)


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.contenttypes/issues/37.