### PR TITLE
Allow patching of searchableText during migrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Allow to patch searchableText index during migrations.
+  [pbauer]
+
+- Expose option to skip catalog-reindex after migration in form.
+  [pbauer]
 
 Bug fixes:
 

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -300,7 +300,7 @@ class IATCTMigratorForm(Interface):
 
     reindex_catalog = schema.Bool(
         title=_(u'Rebuild the catalog after the migration.'),
-        description=_(u'This operantion can take a very long time.'),
+        description=_(u'This operation can take a very long time.'),
         default=True,
         required=False,
     )
@@ -308,7 +308,7 @@ class IATCTMigratorForm(Interface):
     patch_searchabletext = schema.Bool(
         title=_(u'Disable reindexing objects during migration?'),
         description=_(
-            u'This can speed up your migration a lot if you have a lot of files with searchabe text.'
+            u'This can speed up your migration a lot if you have a lot of files with searchable text.'  # noqa: E501
         ),
         default=False,
         required=False,

--- a/plone/app/contenttypes/migration/custom_migration.pt
+++ b/plone/app/contenttypes/migration/custom_migration.pt
@@ -99,7 +99,7 @@
 
             <input class="field" type="checkbox" name="patch_searchabletext" id="patch_searchabletext" />
             <label for="patch_searchabletext" i18n:translate="">Disable reindexing objects during migration</label>
-            <span class="formHelp" id="patch_searchabletext_help" i18n:translate="">This can speed up your migration a lot if you have a lot of files with searchabe text.</span>
+            <span class="formHelp" id="patch_searchabletext_help" i18n:translate="">This can speed up your migration a lot if you have a lot of files with searchable text.</span>
 
             <table>
                 <tr tal:repeat="at_type at_types">

--- a/plone/app/contenttypes/migration/custom_migration.pt
+++ b/plone/app/contenttypes/migration/custom_migration.pt
@@ -96,6 +96,11 @@
             <p i18n:translate="">You can select which AT content type you want to migrate to an existing DX content type.</p>
             <form id="migrateCustomATForm" method="post"
                   tal:attributes="action python:context.absolute_url() + '/@@custom_migration'">
+
+            <input class="field" type="checkbox" name="patch_searchabletext" id="patch_searchabletext" />
+            <label for="patch_searchabletext" i18n:translate="">Disable reindexing objects during migration</label>
+            <span class="formHelp" id="patch_searchabletext_help" i18n:translate="">This can speed up your migration a lot if you have a lot of files with searchabe text.</span>
+
             <table>
                 <tr tal:repeat="at_type at_types">
                   <tal:block tal:define="safe_at_id python:at_type['id'].replace(' ', '_space_')">

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -470,7 +470,13 @@ def makeCustomATMigrator(
     return CustomATMigrator
 
 
-def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
+def migrateCustomAT(fields_mapping,
+                    src_type,
+                    dst_type,
+                    dry_run=False,
+                    patch_linkintegrity=False,
+                    patch_searchabletext=False,
+                    ):
     """
     Try to get types infos from archetype_tool, then set a migrator and pass it
     given values. There is a dry_run mode that allows to check the success of
@@ -479,7 +485,9 @@ def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
     portal = getSite()
 
     # Patch various things that make migration harder
-    link_integrity, queue_indexing = patch_before_migration()
+    (link_integrity,
+     queue_indexing,
+     patch_searchabletext) = patch_before_migration(patch_searchabletext)
 
     # if the type still exists get the src_meta_type from the portal_type
     portal_types = getToolByName(portal, 'portal_types')
@@ -542,6 +550,7 @@ def migrateCustomAT(fields_mapping, src_type, dst_type, dry_run=False):
             transaction.abort()
 
     # Revert to the original state
-    undo_patch_after_migration(link_integrity, queue_indexing)
+    undo_patch_after_migration(
+        link_integrity, queue_indexing, patch_searchabletext)
 
     return walker_infos

--- a/plone/app/contenttypes/migration/patches.py
+++ b/plone/app/contenttypes/migration/patches.py
@@ -22,6 +22,10 @@ def pass_fn(*args, **kwargs):
     """Empty function used for patching."""
     pass
 
+def patched_index_object(*args, **kwargs):
+    """Patched Products.ZCTextIndex.ZCTextIndex.ZCTextIndex.index_object"""
+    return 1
+
 
 # Prevent UUID Error-Messages when migrating folders.
 # Products.PluginIndexes.UUIDIndex.UUIDIndex.UUIDIndex.insertForwardIndexEntry
@@ -145,7 +149,7 @@ def unpatch_indexing_at_blobs():
 
 def patch_indexing_dx_blobs():
     from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
-    patch(ZCTextIndex, 'index_object', pass_fn)
+    patch(ZCTextIndex, 'index_object', patched_index_object)
 
 
 def unpatch_indexing_dx_blobs():

--- a/plone/app/contenttypes/migration/patches.py
+++ b/plone/app/contenttypes/migration/patches.py
@@ -22,9 +22,10 @@ def pass_fn(*args, **kwargs):
     """Empty function used for patching."""
     pass
 
+
 def patched_index_object(*args, **kwargs):
     """Patched Products.ZCTextIndex.ZCTextIndex.ZCTextIndex.index_object"""
-    return 1
+    return 0
 
 
 # Prevent UUID Error-Messages when migrating folders.

--- a/plone/app/contenttypes/tests/test_migration.py
+++ b/plone/app/contenttypes/tests/test_migration.py
@@ -1609,7 +1609,7 @@ class MigrateFromATContentTypesTest(unittest.TestCase):
         # request was constructed before. Otherwise, @@view cannot be render
         # it's IRichText widget.
         alsoProvides(self.request, IPloneFormLayer)
-        at_document_view = at_document.restrictedTraverse('')
+        at_document_view = at_document.restrictedTraverse('document_view')
         self.assertTrue(
             'http://nohost/plone/@@atct_migrator' in at_document_view()
         )
@@ -1619,7 +1619,7 @@ class MigrateFromATContentTypesTest(unittest.TestCase):
         self.assertTrue(IDocument.providedBy(dx_document))
         dx_document_view = dx_document.restrictedTraverse('@@view')
         self.assertFalse('alert-box' in dx_document_view())
-        at_newsitem_view = at_newsitem.restrictedTraverse('')
+        at_newsitem_view = at_newsitem.restrictedTraverse('newsitem_view')
         self.assertTrue('alert-box' in at_newsitem_view())
         self.assertTrue(
             'http://nohost/plone/@@atct_migrator' in at_newsitem_view()


### PR DESCRIPTION
* Allow to patch searchableText index during migrations
* Expose option to skip catalog-reindex after migration in form