### PR TITLE
check if a contentrule exists before assignment on migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Bug fixes:
 - Skip migration tests if ATContentTypes is not installed.
   [davisagli]
 
+- check if a contentrule exists before assignment on migration
+  [MrTango]
+
 
 1.4.10 (2018-04-03)
 -------------------
@@ -104,7 +107,6 @@ Bug fixes:
 
 - Don't overwrite existing settings for Plone Site.
   [roel]
-
 
 1.4.5 (2017-10-06)
 ------------------

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -17,6 +17,7 @@ from plone.app.linkintegrity.handlers import modifiedDexterity
 from plone.app.linkintegrity.handlers import referencedRelationship
 from plone.app.uuid.utils import uuidToObject
 from plone.contentrules.engine.interfaces import IRuleAssignmentManager
+from plone.contentrules.engine.interfaces import IRuleStorage
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.portlets.constants import CONTEXT_BLACKLIST_STATUS_KEY
@@ -181,7 +182,16 @@ def copy_contentrules(source_object, target_object):
                 )
             )
             return
+        rules_storage = getUtility(IRuleStorage)
+        available_rules = [r for r in rules_storage]
         for rule_id in source_assignable:
+            if rule_id not in available_rules:
+                logger.info(
+                    'Contentrule {0} does not exist, skip assignment!'.format(
+                        rule_id
+                    )
+                )
+                continue
             assign_rule(target_object, rule_id)
 
 


### PR DESCRIPTION
In the case some rules where deleted but there are still assignments in the portal, we should skip the assignment on migration.