### PR TITLE
Pass file or image from a webdav PUT to the NamedBlobFile or NamedBlobImage constructor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Pass file or image from a webdav PUT to the NamedBlobFile or NamedBlobImage
+  constructor. This requires plone.app.blob that includes the plone.namedfile
+  storage utility for the custom TemporaryFileWrapper.
+  [enfold-josh]
 
 New features:
 

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -91,7 +91,7 @@ class File(Item):
         infile = request.get('BODYFILE', None)
         filename = request['PATH_INFO'].split('/')[-1]
         self.file = NamedBlobFile(
-            data=infile.read(), filename=unicode(filename))
+            data=infile, filename=unicode(filename))
 
         modified(self)
         return response
@@ -125,7 +125,7 @@ class Image(Item):
         infile = request.get('BODYFILE', None)
         filename = request['PATH_INFO'].split('/')[-1]
         self.image = NamedBlobImage(
-            data=infile.read(), filename=unicode(filename))
+            data=infile, filename=unicode(filename))
 
         modified(self)
         return response


### PR DESCRIPTION
This requires plone.app.blob that includes the plone.namedfile storage utility for the custom TemporaryFileWrapper.