### PR TITLE
Rename post_handlers to prevent them to be run as old importSteps. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Rename post_handlers. Fixes https://github.com/plone/Products.CMFPlone/issues/2238
+  [pbauer]
 
 
 1.4.6 (2017-11-26)

--- a/plone/app/contenttypes/profiles.zcml
+++ b/plone/app/contenttypes/profiles.zcml
@@ -9,7 +9,7 @@
     directory="profiles/content"
     description="Plone default content-types (plone.app.contenttypes)"
     provides="Products.GenericSetup.interfaces.EXTENSION"
-    post_handler=".setuphandlers.step_import_content"
+    post_handler=".setuphandlers.import_content"
     />
 
   <!-- All types, no sample content. -->
@@ -19,7 +19,7 @@
     directory="profiles/default"
     description="Plone default content-types (plone.app.contenttypes)"
     provides="Products.GenericSetup.interfaces.EXTENSION"
-    post_handler=".setuphandlers.step_setup_various"
+    post_handler=".setuphandlers.setup_various"
     />
 
   <!-- Uninstall -->

--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -324,7 +324,7 @@ def configure_members_folder(portal, target_language):
             assignable.setBlacklistStatus('content_type', True)
 
 
-def step_import_content(context):
+def import_content(context):
     """Create default content."""
     portal = getSite()
     target_language, is_combined_language, locale = _get_locales_info(portal)
@@ -334,7 +334,7 @@ def step_import_content(context):
     configure_members_folder(portal, target_language)
 
 
-def step_setup_various(context):
+def setup_various(context):
     portal = getSite()
     target_language, is_combined_language, locale = _get_locales_info(portal)
     _setup_calendar(portal, locale)


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2238