### PR TITLE
Do not use `portal_quickinstaller` in the migration form.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ New features:
 
 Bug fixes:
 
+- Do not use ``portal_quickinstaller`` in the migration form.
+  Use ``get_installer`` to check if ``plone.app.contenttypes`` is
+  installed or installable.  Use ``portal_setup`` directly for
+  blacklisting the ``type_info`` step when installing our profile.
+  [maurits]
+
 - Add Python 2 / 3 compatibility
   [pbauer]
 

--- a/plone/app/contenttypes/tests/test_migration.py
+++ b/plone/app/contenttypes/tests/test_migration.py
@@ -26,6 +26,7 @@ from plone.event.interfaces import IEventAccessor
 from plone.namedfile.file import NamedBlobImage
 from plone.testing.z2 import Browser
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import get_installer
 from z3c.relationfield import RelationValue
 from z3c.relationfield.index import dump
 from zc.relation.interfaces import ICatalog
@@ -2053,26 +2054,26 @@ class MigrationFunctionalTests(unittest.TestCase):
             pass
 
     def test_pac_installer_cancel(self):
-        qi = self.portal.portal_quickinstaller
+        qi = get_installer(self.portal)
         portal_types = self.portal.portal_types
         self.browser.open('{0}/@@pac_installer'.format(self.portal_url))
-        self.assertFalse(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertFalse(qi.is_product_installed('plone.app.contenttypes'))
         self.browser.getControl('Cancel').click()
         self.assertFalse(IDexterityFTI.providedBy(portal_types['Document']))
-        self.assertFalse(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertFalse(qi.is_product_installed('plone.app.contenttypes'))
         self.assertEqual(self.browser.url, self.portal_url)
 
     def test_pac_installer_without_content(self):
-        qi = self.portal.portal_quickinstaller
+        qi = get_installer(self.portal)
         portal_types = self.portal.portal_types
         self.browser.open('{0}/@@pac_installer'.format(self.portal_url))
-        self.assertFalse(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertFalse(qi.is_product_installed('plone.app.contenttypes'))
         self.assertFalse(IDexterityFTI.providedBy(portal_types['Document']))
         self.assertIn('proceed to the migration-form?', self.browser.contents)
         self.browser.getControl('Install').click()
         self.assertTrue(IDexterityFTI.providedBy(portal_types['Document']))
         self.assertTrue(IDexterityFTI.providedBy(portal_types['News Item']))
-        self.assertTrue(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertTrue(qi.is_product_installed('plone.app.contenttypes'))
         self.assertIn('Migration control panel', self.browser.contents)
         self.assertIn('No content to migrate.', self.browser.contents)
 
@@ -2080,16 +2081,16 @@ class MigrationFunctionalTests(unittest.TestCase):
         # add some at content:
         self.portal.invokeFactory('Document', 'doc1')
         transaction.commit()
-        qi = self.portal.portal_quickinstaller
+        qi = get_installer(self.portal)
         portal_types = self.portal.portal_types
         self.browser.open('{0}/@@pac_installer'.format(self.portal_url))
         self.assertFalse(IDexterityFTI.providedBy(portal_types['Document']))
-        self.assertFalse(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertFalse(qi.is_product_installed('plone.app.contenttypes'))
         self.assertIn('proceed to the migration-form?', self.browser.contents)
         self.browser.getControl('Install').click()
         self.assertFalse(IDexterityFTI.providedBy(portal_types['Document']))
         self.assertTrue(IDexterityFTI.providedBy(portal_types['News Item']))
-        self.assertTrue(qi.isProductInstalled('plone.app.contenttypes'))
+        self.assertTrue(qi.is_product_installed('plone.app.contenttypes'))
         self.assertIn('Migration control panel', self.browser.contents)
         self.assertIn('You currently have <span class="strong">1</span> archetypes objects to be migrated.', self.browser.contents)  # noqa
 

--- a/plone/app/contenttypes/tests/test_migration_custom.py
+++ b/plone/app/contenttypes/tests/test_migration_custom.py
@@ -222,12 +222,12 @@ class MigrateCustomATTest(unittest.TestCase):
         from plone.app.contenttypes.migration.migration import migrateCustomAT
         from plone.app.contenttypes.interfaces import INewsItem
         at_document = self.createCustomATDocument('foo-document')
-        qi = self.portal.portal_quickinstaller
         # install pac but only install News Items
-        qi.installProduct(
-            'plone.app.contenttypes',
-            profile='plone.app.contenttypes:default',
-            blacklistedSteps=['typeinfo'])
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        portal_setup.runAllImportStepsFromProfile(
+            'profile-plone.app.contenttypes:default',
+            blacklisted_steps=['typeinfo'],
+        )
         installTypeIfNeeded('News Item')
         fields_mapping = (
             {'AT_field_name': 'textExtended',
@@ -285,12 +285,12 @@ class MigrateCustomATTest(unittest.TestCase):
         oldTZ = os.environ.get('TZ', None)
         os.environ['TZ'] = 'Asia/Tbilisi'
 
-        qi = self.portal.portal_quickinstaller
         # install pac but only install News Items
-        qi.installProduct(
-            'plone.app.contenttypes',
-            profile='plone.app.contenttypes:default',
-            blacklistedSteps=['typeinfo'])
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        portal_setup.runAllImportStepsFromProfile(
+            'profile-plone.app.contenttypes:default',
+            blacklisted_steps=['typeinfo'],
+        )
         installTypeIfNeeded('News Item')
         fields_mapping = (
             {'AT_field_name': 'text',
@@ -359,12 +359,12 @@ class MigrateCustomATTest(unittest.TestCase):
         os.environ['TZ'] = TZ
         timezone = pytz.timezone(TZ)
 
-        qi = self.portal.portal_quickinstaller
         # install pac but only install Event
-        qi.installProduct(
-            'plone.app.contenttypes',
-            profile='plone.app.contenttypes:default',
-            blacklistedSteps=['typeinfo'])
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        portal_setup.runAllImportStepsFromProfile(
+            'profile-plone.app.contenttypes:default',
+            blacklisted_steps=['typeinfo'],
+        )
         installTypeIfNeeded('Event')
         fields_mapping = (
             {'AT_field_name': 'startDate',
@@ -431,12 +431,12 @@ class MigrateCustomATTest(unittest.TestCase):
             u'Some | field is | pipe-delimited | in the field\n'
         )
         at_document.setText(at_text)
-        qi = self.portal.portal_quickinstaller
         # install pac but only install News Items
-        qi.installProduct(
-            'plone.app.contenttypes',
-            profile='plone.app.contenttypes:default',
-            blacklistedSteps=['typeinfo'])
+        portal_setup = getToolByName(self.portal, 'portal_setup')
+        portal_setup.runAllImportStepsFromProfile(
+            'profile-plone.app.contenttypes:default',
+            blacklisted_steps=['typeinfo'],
+        )
         installTypeIfNeeded('News Item')
         fields_mapping = (
             {'AT_field_name': 'text',


### PR DESCRIPTION
Use `get_installer` to check if `plone.app.contenttypes` is installed or installable.
Use `portal_setup` directly for blacklisting the `type_info` step when installing our profile.