### PR TITLE
Made members folder private

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Members folder made permanently private. Fixes https://github.com/plone/Products.CMFPlone/issues/2259
+  [mrsaicharan1]
 
 Bug fixes:
 

--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -307,7 +307,6 @@ def configure_members_folder(portal, target_language):
         container = addContentToContainer(portal, container)
         container.setOrdering('unordered')
         container.reindexObject()
-        _publish(container)
 
         # set member search as default layout to Members Area
         container.setLayout('@@member-search')

--- a/plone/app/contenttypes/tests/test_content_profile.py
+++ b/plone/app/contenttypes/tests/test_content_profile.py
@@ -93,6 +93,12 @@ class ContentProfileTestCase(unittest.TestCase):
         self.assertTrue(assignable_manager.getBlacklistStatus('context'))
         self.assertTrue(assignable_manager.getBlacklistStatus('group'))
         self.assertTrue(assignable_manager.getBlacklistStatus('content_type'))
+        
+    def test_Members_is_private(self):
+        # Is the content object public?
+        obj = self.portal['Members']
+        current_state = self.portal_workflow.getInfoFor(obj, 'review_state')
+        self.assertEqual(current_state, 'private')
 
     # ################ #
     #   events tests   #

--- a/plone/app/contenttypes/tests/test_content_profile.py
+++ b/plone/app/contenttypes/tests/test_content_profile.py
@@ -94,12 +94,6 @@ class ContentProfileTestCase(unittest.TestCase):
         self.assertTrue(assignable_manager.getBlacklistStatus('group'))
         self.assertTrue(assignable_manager.getBlacklistStatus('content_type'))
 
-    def test_Members_is_published(self):
-        # Has the content object been published?
-        obj = self.portal['Members']
-        current_state = self.portal_workflow.getInfoFor(obj, 'review_state')
-        self.assertEqual(current_state, 'published')
-
     # ################ #
     #   events tests   #
     # ################ #


### PR DESCRIPTION
By making the following changes, I have tried to solve issue plone/Products.CMFPlone#2259.
1. Added a changelog entry about the following changes a feature update.
2. Removed the publish method in the setuphandlers.py
3. Fixed the failing test which checks if the members folder is public.
I had a minor doubt regarding the test check. Do I have to remove the following test check or do I have to make a separate method to check if the folder is private?
