### PR TITLE
Fix content types icon_expr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,18 +14,12 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix content types ``icon_expr`` (`issue 372 <https://github.com/plone/plone.app.contenttypes/issues/372>`_).
+  [hvelarde]
+
 
 1.1.5 (2017-10-06)
 ------------------
-
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
 
 Bug fixes:
 

--- a/plone/app/contenttypes/profiles/default/metadata.xml
+++ b/plone/app/contenttypes/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
- <version>1106</version>
+ <version>1107</version>
  <dependencies>
   <dependency>profile-plone.app.dexterity:default</dependency>
   <dependency>profile-plone.app.event:default</dependency>

--- a/plone/app/contenttypes/profiles/default/types/Collection.xml
+++ b/plone/app/contenttypes/profiles/default/types/Collection.xml
@@ -7,6 +7,7 @@
   <property name="title" i18n:translate="">Collection</property>
   <property name="description"
     i18n:translate="">Collection</property>
+  <property name="icon_expr">string:${portal_url}/topic_icon.png</property>
   <property name="global_allow">True</property>
   <property name="filter_content_types">False</property>
   <property name="allowed_content_types" />

--- a/plone/app/contenttypes/profiles/default/types/Document.xml
+++ b/plone/app/contenttypes/profiles/default/types/Document.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">Page</property>
  <property name="description" i18n:translate=""></property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/document_icon.png</property>
  <property name="factory">Document</property>
  <property name="add_view_expr">string:${folder_url}/++add++Document</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/profiles/default/types/Event.xml
+++ b/plone/app/contenttypes/profiles/default/types/Event.xml
@@ -5,7 +5,7 @@
  <!-- Basic properties -->
  <property name="title" i18n:translate="">Event</property>
  <property name="description" i18n:translate="">Events can be shown in calendars.</property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/event_icon.png</property>
  <property name="allow_discussion">False</property>
 
  <property name="factory">Event</property>

--- a/plone/app/contenttypes/profiles/default/types/File.xml
+++ b/plone/app/contenttypes/profiles/default/types/File.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">File</property>
  <property name="description" i18n:translate="">Lets you upload a file to the site.</property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/file_icon.png</property>
  <property name="factory">File</property>
  <property name="add_view_expr">string:${folder_url}/++add++File</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/profiles/default/types/Folder.xml
+++ b/plone/app/contenttypes/profiles/default/types/Folder.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">Folder</property>
  <property name="description" i18n:translate=""></property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/folder_icon.png</property>
  <property name="factory">Folder</property>
  <property name="add_view_expr">string:${folder_url}/++add++Folder</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/profiles/default/types/Image.xml
+++ b/plone/app/contenttypes/profiles/default/types/Image.xml
@@ -4,7 +4,7 @@
  <property name="title" i18n:translate="">Image</property>
  <property name="description"
      i18n:translate="">Images can be referenced in pages or displayed in an album.</property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/image_icon.png</property>
  <property name="factory">Image</property>
  <property name="add_view_expr">string:${folder_url}/++add++Image</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/profiles/default/types/Link.xml
+++ b/plone/app/contenttypes/profiles/default/types/Link.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">Link</property>
  <property name="description" i18n:translate=""></property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/link_icon.png</property>
  <property name="factory">Link</property>
  <property name="add_view_expr">string:${folder_url}/++add++Link</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/profiles/default/types/News_Item.xml
+++ b/plone/app/contenttypes/profiles/default/types/News_Item.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title" i18n:translate="">News Item</property>
  <property name="description" i18n:translate=""></property>
- <property name="icon_expr"></property>
+ <property name="icon_expr">string:${portal_url}/newsitem_icon.png</property>
  <property name="factory">News Item</property>
  <property name="add_view_expr">string:${folder_url}/++add++News Item</property>
  <property name="link_target"></property>

--- a/plone/app/contenttypes/upgrades.py
+++ b/plone/app/contenttypes/upgrades.py
@@ -232,3 +232,23 @@ def searchabletext_richtext(context):
     for brain in search(portal_type=['Collection', 'Document', 'News Item']):
         obj = brain.getObject()
         obj.reindexObject(idxs=['SearchableText'])
+
+
+def fix_icon_expr(context):
+    """Fix content types icon_expr.
+
+    https://github.com/plone/plone.app.contenttypes/issues/372
+    """
+    fixes = {
+        'Collection': 'topic_icon.png',
+        'Document': 'document_icon.png',
+        'Event': 'event_icon.png',
+        'File': 'file_icon.png',
+        'Folder': 'folder_icon.png',
+        'Image': 'image_icon.png',
+        'Link': 'link_icon.png',
+        'News Item': 'newsitem_icon.png',
+    }
+    types = getToolByName(context, 'portal_types')
+    for k, v in fixes.iteritems():
+        types[k].icon_expr = 'string:${portal_url}/' + v

--- a/plone/app/contenttypes/upgrades.zcml
+++ b/plone/app/contenttypes/upgrades.zcml
@@ -88,4 +88,12 @@
       handler=".upgrades.searchabletext_richtext"
       />
 
+  <genericsetup:upgradeStep
+      source="1106"
+      destination="1107"
+      title="Fix content types icon_expr"
+      profile="plone.app.contenttypes:default"
+      handler=".upgrades.fix_icon_expr"
+      />
+
 </configure>


### PR DESCRIPTION
WIP: fixes #372 ; blocked by #453.

I'm having several issue while trying to fix this:

if I install from scratch, content type icons are fine on the Dexterity configlet, but duplicated on the `Add...` menu:

![screenshot-2018-2-21 bem-vindo ao plone site](https://user-images.githubusercontent.com/341393/36499145-1d69b65c-171f-11e8-8e86-74a1b6dbf6ba.png)

if I run the upgrade step then nothing if fixed, but, worst, the plone.contentactions breaks (maybe I'm doing the update wrong):

![screenshot-2018-2-21 bem-vindo ao plone site 1](https://user-images.githubusercontent.com/341393/36499209-53c51732-171f-11e8-8696-06a03c62ea86.png)
