### PR TITLE
title_or_id fix, layout setting fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Set the ``plone.app.contenttypes_migration_running`` key while running a migration.
+  Other addons can check for that and handle accordingly.
+  [thet]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- In folder listings, when a content object has no title show it's id instead of an empty title.
+  [thet]
 
 1.4.9 (2018-02-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,8 +16,10 @@ New features:
 
 Bug fixes:
 
-- Try to delete the layout attribute before setting the layout.
-  Rework parts where the layout is set by always setting the layout.
+- Migrations:
+  - Handle ignore catalog errors where a brain can't find it's object.
+  - Try to delete the layout attribute before setting the layout.
+    Rework parts where the layout is set by always setting the layout.
   [thet]
 
 - In folder listings, when a content object has no title show it's id instead of an empty title.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Try to delete the layout attribute before setting the layout.
+  Rework parts where the layout is set by always setting the layout.
+  [thet]
+
 - In folder listings, when a content object has no title show it's id instead of an empty title.
   [thet]
 

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -34,6 +34,7 @@
                 item_url item/getURL;
                 item_id item/getId;
                 item_title item/Title;
+                item_title python:item_title or item_id;
                 item_description item/Description;
                 item_type item/PortalType;
                 item_modified item/ModificationDate;

--- a/plone/app/contenttypes/browser/templates/listing_tabular.pt
+++ b/plone/app/contenttypes/browser/templates/listing_tabular.pt
@@ -44,7 +44,9 @@
                              image_scale portal/@@image_scale">
             <tal:entries tal:repeat="item batch">
               <tal:block tal:define="item_url item/getURL;
+                                     item_id item/getId;
                                      item_title item/Title;
+                                     item_title python:item_title or item_id;
                                      item_description item/Description;
                                      item_type item/PortalType;
                                      item_type_class python:'contenttype-' + view.normalizeString(item_type) if showicons else '';

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -84,6 +84,7 @@ class FixBaseClasses(BrowserView):
                 try:
                     obj = brain.getObject()
                 except (KeyError, NotFound):
+                    logger.exception('Can not resolve object from brain.')
                     continue
                 if IDexterityContent.providedBy(obj):
                     object_class_name = obj.__class__.__name__

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -9,13 +9,13 @@ from plone.app.contenttypes.content import Link
 from plone.app.contenttypes.content import NewsItem
 from plone.app.contenttypes.migration import dxmigration
 from plone.app.contenttypes.migration import migration
+from plone.app.contenttypes.migration.patches import patch_before_migration
+from plone.app.contenttypes.migration.patches import undo_patch_after_migration
 from plone.app.contenttypes.migration.utils import installTypeIfNeeded
 from plone.app.contenttypes.migration.utils import isSchemaExtended
 from plone.app.contenttypes.migration.utils import restore_references
 from plone.app.contenttypes.migration.utils import store_references
 from plone.app.contenttypes.migration.vocabularies import ATCT_LIST
-from plone.app.contenttypes.migration.patches import patch_before_migration
-from plone.app.contenttypes.migration.patches import undo_patch_after_migration
 from plone.app.contenttypes.upgrades import use_new_view_names
 from plone.app.contenttypes.utils import DEFAULT_TYPES
 from plone.browserlayer.interfaces import ILocalBrowserLayerType
@@ -34,6 +34,7 @@ from z3c.form import field
 from z3c.form import form
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.interfaces import HIDDEN_MODE
+from zExceptions import NotFound
 from zope import schema
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
@@ -80,7 +81,10 @@ class FixBaseClasses(BrowserView):
             query['portal_type'] = portal_type
             results = catalog(query)
             for brain in results:
-                obj = brain.getObject()
+                try:
+                    obj = brain.getObject()
+                except (KeyError, NotFound):
+                    continue
                 if IDexterityContent.providedBy(obj):
                     object_class_name = obj.__class__.__name__
                     target_class_name = portal_type_class.__name__
@@ -262,7 +266,10 @@ class MigrateFromATContentTypes(BrowserView):
         results = {}
         catalog = self.context.portal_catalog
         for brain in catalog():
-            classname = brain.getObject().__class__.__name__
+            try:
+                classname = brain.getObject().__class__.__name__
+            except (KeyError, NotFound):
+                continue
             results[classname] = results.get(classname, 0) + 1
         return results
 
@@ -431,7 +438,10 @@ class BaseClassMigratorForm(form.Form):
         migrated = []
         not_migrated = []
         for brain in catalog():
-            obj = brain.getObject()
+            try:
+                obj = brain.getObject()
+            except (KeyError, NotFound):
+                continue
             old_class_name = dxmigration.get_old_class_name_string(obj)
             if old_class_name in changed_base_classes:
                 if dxmigration.migrate_base_class_to_new_class(

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -137,6 +137,8 @@ class MigrateFromATContentTypes(BrowserView):
         stats_before = self.stats()
         starttime = datetime.now()
 
+        self.request['plone.app.contenttypes_migration_running'] = True
+
         msg = 'Starting Migration\n\n'
         msg += '\n-----------------------------\n'
         msg += 'Content statictics:\n'

--- a/plone/app/contenttypes/migration/dxmigration.py
+++ b/plone/app/contenttypes/migration/dxmigration.py
@@ -174,7 +174,7 @@ def list_of_objects_with_changed_base_class(context):
     for brain in catalog(object_provides=IDexterityContent.__identifier__):
         try:
             obj = brain.getObject()
-        except NotFound:
+        except (KeyError, NotFound):
             logger.warn('Object {0} not found'.format(brain.getPath()))
             continue
         if get_portal_type_name_string(obj) != get_old_class_name_string(obj):

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -205,10 +205,15 @@ class ATCTFolderMigrator(CMFFolderMigrator):
         migrate_properties.
         """
         old_layout = self.old.getLayout() or getattr(self.old, 'layout', None)
-        if old_layout in LISTING_VIEW_MAPPING.keys():
+        if old_layout:
             default_page = self.old.getDefaultPage() or \
                 getattr(self.old, 'default_page', None)
-            self.new.setLayout(LISTING_VIEW_MAPPING[old_layout])
+            try:
+                # Delete old-style layout attribute.
+                del self.new.layout
+            except AttributeError:
+                pass
+            self.new.setLayout(LISTING_VIEW_MAPPING.get(old_layout, old_layout))  # noqa
             if default_page:
                 # any defaultPage is switched of by setLayout
                 # and needs to set again
@@ -343,10 +348,6 @@ class FolderMigrator(ATCTFolderMigrator):
     dst_portal_type = 'Folder'
     dst_meta_type = None  # not used
 
-    def beforeChange_migrate_layout(self):
-        if self.old.getLayout() == 'atct_album_view':
-            self.old.setLayout('album_view')
-
 
 def migrate_folders(portal):
     return migrate(portal, FolderMigrator)
@@ -381,8 +382,13 @@ class CollectionMigrator(ATCTContentMigrator):
         by a later call to migrate_properties.
         """
         old_layout = self.old.getLayout() or getattr(self.old, 'layout', None)
-        if old_layout in LISTING_VIEW_MAPPING:
-            self.new.setLayout(LISTING_VIEW_MAPPING[old_layout])
+        if old_layout:
+            try:
+                # Delete old-style layout attribute.
+                del self.new.layout
+            except AttributeError:
+                pass
+            self.new.setLayout(LISTING_VIEW_MAPPING.get(old_layout, old_layout))  # noqa
 
 
 def migrate_collections(portal):

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -32,6 +32,7 @@ from Products.contentmigration.basemigrator.migrator import CMFFolderMigrator
 from Products.contentmigration.basemigrator.migrator import CMFItemMigrator
 from Products.contentmigration.basemigrator.walker import CatalogWalker
 from Products.contentmigration.walker import CustomQueryWalker
+from zExceptions import NotFound
 from zope.component import adapter
 from zope.component import getAdapters
 from zope.component import getMultiAdapter
@@ -508,7 +509,13 @@ def migrateCustomAT(fields_mapping,
             is_folderish = False
             src_meta_type = src_type
         else:
-            src_obj = brains[0].getObject()
+            try:
+                src_obj = brains[0].getObject()
+            except (KeyError, NotFound):
+                logger.error(
+                    'Could not find the object for brain at %s',
+                    brains[0].getURL())
+                return
             if IDexterityContent.providedBy(src_obj):
                 logger.error(
                     '%s should not be dexterity object!',

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -34,6 +34,7 @@ from Products.GenericSetup.context import DirectoryImportContext
 from Products.GenericSetup.utils import importObjects
 from z3c.relationfield import RelationValue
 from zc.relation.interfaces import ICatalog
+from zExceptions import NotFound
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getGlobalSiteManager
 from zope.component import getMultiAdapter
@@ -72,7 +73,10 @@ def _compareSchemata(interface):
         if not brain.meta_type or 'dexterity' in brain.meta_type.lower():
             # There might be DX types with same iface and meta_type than AT
             continue
-        obj = brain.getObject()
+        try:
+            obj = brain.getObject()
+        except (KeyError, NotFound):
+            continue
         real_fields = set(obj.Schema()._names)
         orig_fields = set(obj.schema._names)
         diff = [i for i in real_fields.difference(orig_fields)]

--- a/plone/app/contenttypes/tests/test_folder.py
+++ b/plone/app/contenttypes/tests/test_folder.py
@@ -193,3 +193,18 @@ class FolderViewFunctionalTest(unittest.TestCase):
         self.assertIn(
             '<img src="http://nohost/plone/folder/image1/@@images',
             self.browser.contents)
+
+    def test_list_item_wout_title(self):
+        """In content listings, if a content object has no title use it's id.
+        """
+        self.folder.invokeFactory('Document', id='doc_wout_title')
+        import transaction
+        transaction.commit()
+
+        # Document should be shown in listing view (and it's siblings)
+        self.browser.open(self.folder_url + "/listing_view")
+        self.assertIn('doc_wout_title', self.browser.contents)
+
+        # And also in tabular view
+        self.browser.open(self.folder_url + "/tabular_view")
+        self.assertIn('doc_wout_title', self.browser.contents)


### PR DESCRIPTION
- In folder listings, when a content object has no title show it's id instead of an empty title.

- Migrations: Try to delete the layout attribute before setting the layout.
  Rework parts where the layout is set by always setting the layout.