### PR TITLE
Do not encode query strings on internal link redirections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ New features:
 
 Bug fixes:
 
+- Do not encode query strings on internal link redirections;
+  fixes `issue 457 <https://github.com/plone/plone.app.contenttypes/issues/457>`_.
+  [hvelarde]
+
 - Migrations:
   - Handle ignore catalog errors where a brain can't find it's object.
   - Try to delete the layout attribute before setting the layout.

--- a/plone/app/contenttypes/browser/link_redirect_view.py
+++ b/plone/app/contenttypes/browser/link_redirect_view.py
@@ -87,7 +87,7 @@ class LinkRedirectView(BrowserView):
                 url
             ])
         else:
-            if not (url.startswith('http://') or url.startswith('https://')):
-                url = self.request.physicalPathToURL(url)
+            if not url.startswith(('http://', 'https://')):
+                url = self.request['SERVER_URL'] + url
 
         return url

--- a/plone/app/contenttypes/tests/test_link.py
+++ b/plone/app/contenttypes/tests/test_link.py
@@ -160,6 +160,21 @@ class LinkViewIntegrationTest(unittest.TestCase):
         self.assertTrue(view())
         self._assert_redirect('http://nohost/plone/my-folder/my-item')
 
+    def test_link_redirect_view_path_with_variable_and_parameters(self):
+        # https://github.com/plone/plone.app.contenttypes/issues/457
+        self.link.remoteUrl = '${portal_url}/@@search?SearchableText=Plone'
+        self._publish(self.link)
+        view = self._get_link_redirect_view(self.link)
+
+        # As manager: do not redirect
+        self.assertTrue(view())
+        self.assertEqual(self.response.status, 200)
+
+        # As anonymous: redirect
+        logout()
+        self.assertTrue(view())
+        self._assert_redirect('http://nohost/plone/@@search?SearchableText=Plone')
+
     def test_mailto_type(self):
         self.link.remoteUrl = 'mailto:stress@test.us'
         view = self._get_link_redirect_view(self.link)


### PR DESCRIPTION
fixes #457 

cc: @plone/framework-team 