### PR TITLE
Do not encode query strings on internal link redirections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,18 +14,12 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not encode query strings on internal link redirections;
+  fixes `issue 457 <https://github.com/plone/plone.app.contenttypes/issues/457>`_.
+  [hvelarde]
 
 1.1.5 (2017-10-06)
 ------------------
-
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
 
 Bug fixes:
 

--- a/plone/app/contenttypes/browser/link_redirect_view.py
+++ b/plone/app/contenttypes/browser/link_redirect_view.py
@@ -77,7 +77,7 @@ class LinkRedirectView(BrowserView):
             ])
         else:
             url = replace_link_variables_by_paths(self.context, url)
-            if not (url.startswith('http://') or url.startswith('https://')):
-                url = self.request.physicalPathToURL(url)
+            if not url.startswith(('http://', 'https://')):
+                url = self.request['SERVER_URL'] + url
 
         return url

--- a/plone/app/contenttypes/tests/test_link.py
+++ b/plone/app/contenttypes/tests/test_link.py
@@ -154,6 +154,21 @@ class LinkViewIntegrationTest(unittest.TestCase):
         self.assertTrue(view())
         self._assert_redirect('http://nohost/plone/my-folder/my-item')
 
+    def test_link_redirect_view_path_with_variable_and_parameters(self):
+        # https://github.com/plone/plone.app.contenttypes/issues/457
+        self.link.remoteUrl = '${portal_url}/@@search?SearchableText=Plone'
+        self._publish(self.link)
+        view = self._get_link_redirect_view(self.link)
+
+        # As manager: do not redirect
+        self.assertTrue(view())
+        self.assertEqual(self.response.status, 200)
+
+        # As anonymous: redirect
+        logout()
+        self.assertTrue(view())
+        self._assert_redirect('http://nohost/plone/@@search?SearchableText=Plone')
+
     def test_mailto_type(self):
         self.link.remoteUrl = 'mailto:stress@test.us'
         view = self._get_link_redirect_view(self.link)


### PR DESCRIPTION
refs. #457

cc @plone/framework-team 