### PR TITLE
Improve _replace_variable_by_path method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug fixes:
 
 - Fix replace link variable by path for not using acquistion magic.
   [bsuttor]
+
 - When installing the add'on, use portal_languages tool to find the preferred
   language, instead of using a fallback on the Plone Site Root's empty language
   attribute.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Fix replace link variable by path for not using acquistion magic.
+  [bsuttor]
+
 - Implement better human readable file size logic.
   [hvelarde]
 

--- a/plone/app/contenttypes/utils.py
+++ b/plone/app/contenttypes/utils.py
@@ -37,7 +37,7 @@ def replace_link_variables_by_paths(context, url):
 
 
 def _replace_variable_by_path(url, variable, obj):
-    path = '/'.join(obj.getPhysicalPath())
+    path = obj.absolute_url()
     return url.replace(variable, path)
 
 


### PR DESCRIPTION
At this moment we use '/'.join(obj.getPhysicalPath()) to replace
${navigation_root_url} and ${portal_url} in Link redirection but with
production site, it seems use acquisition to get correct link.

Example for same portal in production and in development:

production
https://mysite.com/my-folder/my-link
with remoteUrl = ${navigation_root_url}/my-other-folder

in local
http://localhost:8080/plone/my-folder/my-link
with same remoteUrl

generated link in local is good (http://localhost:8080/plone/my-other-folder/)
but in production, it's not correct, indeed it's
https://mysite.com/plone/my-other-folder/, and it should be
https://mysite.com/my-other-folder/

'plone' path should not be in link.
It maybe works with acquisition, but it's not correct .
So I simply replace '/'.join(obj.getPhysicalPath()) by
obj.absolute_url()

Is there good reason to use getPhysicalPath instead of absolute_url ?