### PR TITLE
 When installing the add'on, use portal_languages tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New features:
 
 Bug fixes:
 
+- When installing the add'on, use portal_languages tool to find the preferred
+  language, instead of using a fallback on the Plone Site Root's empty language
+  attribute.
+  [fredvd]
+
 - Implement better human readable file size logic.
   [hvelarde]
 

--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -108,7 +108,11 @@ def addContentToContainer(container, object, checkConstraints=True):
 
 
 def _get_locales_info(portal):
-    language = portal.Language()
+    ltool = getToolByName(portal, 'portal_languages')
+    language = ltool.getPreferredLanguage()
+    # Original method, but probably only valid for Plone < 3.
+    if not language:
+        language = portal.Language()
     parts = (language.split('-') + [None, None])[:3]
     locale = locales.getLocale(*parts)
 


### PR DESCRIPTION
to find the preferred language, instead of using a fallback on the
Plone Site Root's empty language attribute. That probably worked
only  in Plone < 3.