### PR TITLE
When installing in the add'ons controlpanel, use portal_languages tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ New features:
 
 Bug fixes:
 
+- When installing in the add'ons controlpanel, use portal_languages tool to find
+  the preferred language, instead of risking a fallback on the Plone siteRoot's
+  empty language attribute.
+  [fredvd]
+
 - Implement better human readable file size logic.
   [hvelarde]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -117,3 +117,6 @@ zc.recipe.egg = 2.0.3
 plone.app.event = <= 1.1.999
 plone.event = < 2.0
 createcoverage = 1.3.2
+
+# get the buildout to run until we have a new Plone 4.3 release
+plone.recipe.zope2instance = 4.4.0

--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -108,7 +108,8 @@ def addContentToContainer(container, object, checkConstraints=True):
 
 
 def _get_locales_info(portal):
-    language = portal.Language()
+    ltool = getToolByName(portal, 'portal_languages')
+    language = ltool.getPreferredLanguage()
     parts = (language.split('-') + [None, None])[:3]
     locale = locales.getLocale(*parts)
 
@@ -120,7 +121,7 @@ def _get_locales_info(portal):
 
 
 def _set_language_settings(portal, uses_combined_lanagage):
-    """Set the portals language settings from the given lanage codes."""
+    """Set the portals language settings from the given language codes."""
     language = portal.Language()
     portal_languages = getToolByName(portal, 'portal_languages')
     portal_languages.manage_setLanguageSettings(


### PR DESCRIPTION
get buildout to run until 4.3.18 is released
fix typo