### PR TITLE
backport migration fixes from master for layouts and brain .getObject()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Bug fixes:
 - Implement better human readable file size logic.
   [hvelarde]
 
+- Migrations:
+   - Handle ignore catalog errors where a brain can't find it's object.
+   - Try to delete the layout attribute before setting the layout.
+     Rework parts where the layout is set by always setting the layout.
+  [thet, backport by fredvd]
 
 1.1.6 (2018-03-28)
 ------------------

--- a/plone/app/contenttypes/migration/browser.py
+++ b/plone/app/contenttypes/migration/browser.py
@@ -42,6 +42,7 @@ from z3c.form import field
 from z3c.form import form
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.interfaces import HIDDEN_MODE
+from zExceptions import NotFound
 from zope import schema
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -100,7 +101,10 @@ class FixBaseClasses(BrowserView):
             query['portal_type'] = portal_type
             results = catalog(query)
             for brain in results:
-                obj = brain.getObject()
+                try:
+                    obj = brain.getObject()
+                except (KeyError, NotFound):
+                    continue
                 if IDexterityContent.providedBy(obj):
                     object_class_name = obj.__class__.__name__
                     target_class_name = portal_type_class.__name__
@@ -298,7 +302,10 @@ class MigrateFromATContentTypes(BrowserView):
         if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
             query['Language'] = 'all'
         for brain in catalog(query):
-            classname = brain.getObject().__class__.__name__
+            try:
+                classname = brain.getObject().__class__.__name__
+            except (KeyError, NotFound):
+                continue
             results[classname] = results.get(classname, 0) + 1
         return results
 
@@ -454,7 +461,10 @@ class BaseClassMigratorForm(form.Form):
         migrated = []
         not_migrated = []
         for brain in catalog():
-            obj = brain.getObject()
+            try:
+                obj = brain.getObject()
+            except (KeyError, NotFound):
+                continue
             old_class_name = dxmigration.get_old_class_name_string(obj)
             if old_class_name in changed_base_classes:
                 if dxmigration.migrate_base_class_to_new_class(

--- a/plone/app/contenttypes/migration/custom_migration.py
+++ b/plone/app/contenttypes/migration/custom_migration.py
@@ -10,6 +10,7 @@ from plone.app.contenttypes.migration.migration import migrateCustomAT
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import iterSchemataForType
+from zExceptions import NotFound
 from zope.i18n import translate
 import json
 import logging
@@ -104,7 +105,11 @@ class CustomMigrationForm(BrowserView):
         for meta_type in catalog.uniqueValuesFor('meta_type'):
             # querying for meta_type will only return at-types
             brain = catalog(meta_type=meta_type, sort_limit=1)[0]
-            if IDexterityContent.providedBy(brain.getObject()):
+            try:
+                obj = brain.getObject()
+            except (KeyError, NotFound):
+                continue
+            if IDexterityContent.providedBy(obj):
                 continue
             typename = brain.portal_type
             if typename not in all_registered_types:
@@ -168,7 +173,10 @@ class CustomMigrationForm(BrowserView):
         brains = catalog(portal_type=typename, sort_limit=1)
         if not brains:
             return results
-        obj = brains[0].getObject()
+        try:
+            obj = brains[0].getObject()
+        except (KeyError, NotFound):
+            return results
         for field_name in obj.schema._fields:
             field = obj.schema._fields[field_name]
             if not field.getName() in self.at_metadata_fields:

--- a/plone/app/contenttypes/migration/dxmigration.py
+++ b/plone/app/contenttypes/migration/dxmigration.py
@@ -177,7 +177,7 @@ def list_of_objects_with_changed_base_class(context):
     for brain in catalog(query):
         try:
             obj = brain.getObject()
-        except NotFound:
+        except (KeyError, NotFound):
             logger.warn("Object {0} not found".format(brain.getPath()))
             continue
         if get_portal_type_name_string(obj) != get_old_class_name_string(obj):

--- a/plone/app/contenttypes/migration/utils.py
+++ b/plone/app/contenttypes/migration/utils.py
@@ -34,6 +34,7 @@ from plone.portlets.interfaces import IPortletManager
 from plone.uuid.interfaces import IUUID
 from z3c.relationfield import RelationValue
 from zc.relation.interfaces import ICatalog
+from zExceptions import NotFound
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getGlobalSiteManager
 from zope.component import getMultiAdapter
@@ -81,7 +82,10 @@ def _compareSchemata(interface):
         if not brain.meta_type or 'dexterity' in brain.meta_type.lower():
             # There might be DX types with same iface and meta_type than AT
             continue
-        obj = brain.getObject()
+        try:
+            obj = brain.getObject()
+        except (KeyError, NotFound):
+            continue
         real_fields = set(obj.Schema()._names)
         orig_fields = set(obj.schema._names)
         diff = [i for i in real_fields.difference(orig_fields)]


### PR DESCRIPTION
backport migration fixes from master for layouts and brain .getObject() failures and layout settings.  These are commits d6e280b80320654d3766c06359b5d1d82853cc5b and 0b1d57800cd91dbe9cf79a74beefefbb00d977fe. 

Ran into these while moving a 4.3.x site to plone.app.contenttypes 1.1.6