### PR TITLE
Fix the Format accessor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- The ``Format`` accessor should actually return the ``format`` attribute
+  (see plone/Products.CMFPlone#2540)
+  [ale-rt]
 
 
 1.4.12 (2018-09-23)

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -76,6 +76,14 @@ class Collection(Item):
 class Document(Item):
     """Convenience subclass for ``Document`` portal type
     """
+    def Format(self):
+        ''' Provide a proper accessor for the format attribute
+        See https://github.com/plone/Products.CMFPlone/issues/2540
+        '''
+        format = self.format
+        if six.PY2 and isinstance(format, six.text_type):
+            format = self.format.encode()
+        return format
 
 
 @implementer(IFile)


### PR DESCRIPTION
The ``Format`` accessor should actually return the ``format`` attribute
(see plone/Products.CMFPlone#2540)