### PR TITLE
Fix the Format accessor (1.2.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- The ``Format`` accessor should actually return the ``format`` attribute
+  (see plone/Products.CMFPlone#2540)
+  [ale-rt]
 
 
 1.2.26 (2017-10-06)

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -73,6 +73,14 @@ class Collection(Item):
 class Document(Item):
     """Convenience subclass for ``Document`` portal type
     """
+    def Format(self):
+        ''' Provide a proper accessor for the format attribute
+        See https://github.com/plone/Products.CMFPlone/issues/2540
+        '''
+        format = self.format
+        if six.PY2 and isinstance(format, six.text_type):
+            format = self.format.encode()
+        return format
 
 
 @implementer(IFile)

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -15,6 +15,8 @@ from zope.deprecation import deprecation
 from zope.interface import implementer
 from zope.lifecycleevent import modified
 
+import six
+
 
 @implementer(ICollection)
 class Collection(Item):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name='plone.app.contenttypes',
           'plone.app.lockingbehavior',
           'pytz',
           'plone.app.z3cform>=1.1.0.dev0',
+          'six',
           'zope.deprecation',
       ],
       extras_require={


### PR DESCRIPTION
The ``Format`` accessor should actually return the ``format`` attribute
(see plone/Products.CMFPlone#2540)