### PR TITLE
Let folderListing know about the orphan parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Fixed sorting error after Changing the base class for existing objects.
   see `issue <https://github.com/plone/plone.app.contenttypes/issues/487>`
   [jianaijun]
+- Fix for folder view when there is one item more than the batch size.
+  see `issue <https://github.com/plone/plone.app.contenttypes/issues/500>`
+  [reinhardt]
 
 
 2.0.0 (2018-10-30)

--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -89,6 +89,7 @@ class FolderView(BrowserView):
         kwargs.setdefault('batch', True)
         kwargs.setdefault('b_size', self.b_size)
         kwargs.setdefault('b_start', self.b_start)
+        kwargs.setdefault('orphan', 1)
 
         listing = aq_inner(self.context).restrictedTraverse(
             '@@folderListing', None)

--- a/plone/app/contenttypes/tests/test_folder.py
+++ b/plone/app/contenttypes/tests/test_folder.py
@@ -98,6 +98,33 @@ class FolderViewIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(len(res), 1)
 
+    def test_result_batching(self):
+        for idx in range(5):
+            self.portal.invokeFactory('Document', 'document{}'.format(idx))
+        request = self.request.clone()
+        request.form['b_size'] = 5
+        view = FolderView(self.portal, request)
+
+        batch = view.batch()
+        self.assertEqual(batch.length, 5)
+        self.assertEqual(len([item for item in batch]), 5)
+        self.assertFalse(batch.has_next)
+
+        self.portal.invokeFactory('Document', 'document5')
+
+        batch = view.batch()
+        self.assertEqual(batch.length, 6)
+        self.assertEqual(len([item for item in batch]), 6)
+        self.assertFalse(batch.has_next)
+
+        self.portal.invokeFactory('Document', 'document6')
+
+        batch = view.batch()
+        self.assertEqual(batch.length, 5)
+        self.assertEqual(len([item for item in batch]), 5)
+        self.assertTrue(batch.has_next)
+        self.assertEqual(batch.next_item_count, 2)
+
 
 class FolderFunctionalTest(unittest.TestCase):
 


### PR DESCRIPTION
Fixes folder view when there is one item more than the batch size.
Closes #500