### PR TITLE
Bring back external editor support

### DIFF
--- a/news/2781.bugfix
+++ b/news/2781.bugfix
@@ -1,0 +1,1 @@
+Detect whether a webdav request is RFC822 or pure payload and handle accordingly.

--- a/plone/app/contenttypes/content.py
+++ b/plone/app/contenttypes/content.py
@@ -12,6 +12,7 @@ from plone.dexterity.content import Container
 from plone.dexterity.content import Item
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
+from Products.CMFPlone.utils import safe_text
 from zope.deprecation import deprecation
 from zope.interface import implementer
 from zope.lifecycleevent import modified
@@ -100,7 +101,7 @@ class File(Item):
         infile = request.get('BODYFILE', None)
         first_line = infile.readline()
         infile.seek(0)
-        if not headerRE.match(first_line):
+        if not headerRE.match(safe_text(first_line)):
             self.dav__init(request, response)
             self.dav__simpleifhandler(request, response, refresh=1)
 
@@ -139,7 +140,7 @@ class Image(Item):
         infile = request.get('BODYFILE', None)
         first_line = infile.readline()
         infile.seek(0)
-        if not headerRE.match(first_line):
+        if not headerRE.match(safe_text(first_line)):
             self.dav__init(request, response)
             self.dav__simpleifhandler(request, response, refresh=1)
 

--- a/plone/app/contenttypes/tests/test_webdav.py
+++ b/plone/app/contenttypes/tests/test_webdav.py
@@ -7,7 +7,15 @@ from zope.publisher.browser import TestRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
 import os.path
+import pkg_resources
 import unittest
+
+
+HAS_ZSERVER = True
+try:
+    dist = pkg_resources.get_distribution('ZServer')
+except pkg_resources.DistributionNotFound:
+    HAS_ZSERVER = False
 
 
 class DAVTestRequest(TestRequest):
@@ -61,6 +69,7 @@ class WebDAVIntegrationTest(unittest.TestCase):
         self.assertEqual(self.file.get_size(), 8561)
         self.assertEqual(self.file.content_type(), 'application/pdf')
 
+    @unittest.skipIf(not HAS_ZSERVER, 'RFC822 not supported without ZServer')
     def test_image_put_rfc822(self):
         """Upload an image through webdav/rfc822."""
         filename = os.path.join(os.path.dirname(__file__), u'image.jpg')
@@ -83,6 +92,7 @@ Portal-Type: Image
         self.assertEqual(self.image.get_size(), 5131)
         self.assertEqual(self.image.content_type(), 'image/jpeg')
 
+    @unittest.skipIf(not HAS_ZSERVER, 'RFC822 not supported without ZServer')
     def test_file_put_rfc822(self):
         """Upload a file through webdav/rfc822."""
         filename = os.path.join(os.path.dirname(__file__), u'file.pdf')

--- a/plone/app/contenttypes/tests/test_webdav.py
+++ b/plone/app/contenttypes/tests/test_webdav.py
@@ -2,6 +2,7 @@
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING  # noqa
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from six.moves import StringIO
 from zope.publisher.browser import TestRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
@@ -52,6 +53,50 @@ class WebDAVIntegrationTest(unittest.TestCase):
         filename = os.path.join(os.path.dirname(__file__), u'file.pdf')
         request = DAVTestRequest(environ={
             'BODYFILE': open(filename, 'rb'),
+            'PATH_INFO': '/foo/bar/file.pdf',
+        })
+        self.file.REQUEST = request
+        self.file.PUT()
+        self.assertEqual(self.file.file.filename, u'file.pdf')
+        self.assertEqual(self.file.get_size(), 8561)
+        self.assertEqual(self.file.content_type(), 'application/pdf')
+
+    def test_image_put_rfc822(self):
+        """Upload an image through webdav/rfc822."""
+        filename = os.path.join(os.path.dirname(__file__), u'image.jpg')
+        body = StringIO()
+        body.write("""title: My image
+Content-Type: image/jpeg
+Content-Disposition: attachment; filename*="utf-8''image.jpg"
+Portal-Type: Image
+
+{body}""".format(body=open(filename, 'rb').read())
+        )
+        body.seek(0)
+        request = DAVTestRequest(environ={
+            'BODYFILE': body,
+            'PATH_INFO': '/foo/bar/image.jpg',
+        })
+        self.image.REQUEST = request
+        self.image.PUT()
+        self.assertEqual(self.image.image.filename, u'image.jpg')
+        self.assertEqual(self.image.get_size(), 5131)
+        self.assertEqual(self.image.content_type(), 'image/jpeg')
+
+    def test_file_put_rfc822(self):
+        """Upload a file through webdav/rfc822."""
+        filename = os.path.join(os.path.dirname(__file__), u'file.pdf')
+        body = StringIO()
+        body.write("""title: My file
+Content-Type: application/pdf
+Content-Disposition: attachment; filename*="utf-8''file.pdf"
+Portal-Type: File
+
+{body}""".format(body=open(filename, 'rb').read())
+        )
+        body.seek(0)
+        request = DAVTestRequest(environ={
+            'BODYFILE': body,
             'PATH_INFO': '/foo/bar/file.pdf',
         })
         self.file.REQUEST = request

--- a/plone/app/contenttypes/tests/test_webdav.py
+++ b/plone/app/contenttypes/tests/test_webdav.py
@@ -2,7 +2,7 @@
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING  # noqa
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from six.moves import StringIO
+from io import BytesIO
 from zope.publisher.browser import TestRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
@@ -64,13 +64,13 @@ class WebDAVIntegrationTest(unittest.TestCase):
     def test_image_put_rfc822(self):
         """Upload an image through webdav/rfc822."""
         filename = os.path.join(os.path.dirname(__file__), u'image.jpg')
-        body = StringIO()
-        body.write("""title: My image
+        body = BytesIO()
+        body.write(b"""title: My image
 Content-Type: image/jpeg
 Content-Disposition: attachment; filename*="utf-8''image.jpg"
 Portal-Type: Image
 
-{body}""".format(body=open(filename, 'rb').read())
+""" + open(filename, 'rb').read()
         )
         body.seek(0)
         request = DAVTestRequest(environ={
@@ -86,13 +86,13 @@ Portal-Type: Image
     def test_file_put_rfc822(self):
         """Upload a file through webdav/rfc822."""
         filename = os.path.join(os.path.dirname(__file__), u'file.pdf')
-        body = StringIO()
-        body.write("""title: My file
+        body = BytesIO()
+        body.write(b"""title: My file
 Content-Type: application/pdf
 Content-Disposition: attachment; filename*="utf-8''file.pdf"
 Portal-Type: File
 
-{body}""".format(body=open(filename, 'rb').read())
+""" + open(filename, 'rb').read()
         )
         body.seek(0)
         request = DAVTestRequest(environ={


### PR DESCRIPTION
Detect whether a webdav request is RFC822 or pure payload and handle acordingly so that external editor and classic webdav clients are both supported.

Fixes https://github.com/plone/Products.CMFPlone/issues/2781