### PR TITLE
Explicitly load zcml of dependencies.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Explicitly load zcml of dependencies, instead of using ``includeDependencies``
+[maurits]

--- a/plone/app/contenttypes/configure.zcml
+++ b/plone/app/contenttypes/configure.zcml
@@ -7,8 +7,25 @@
            xmlns:plone="http://namespaces.plone.org/plone"
            i18n_domain="plone">
 
-  <includeDependencies package="." />
+  <include package="Products.CMFPlone" file="meta.zcml"/>
+  <include package="plone.behavior" file="meta.zcml"/>
+  <include package="plone.dexterity" file="meta.zcml"/>
+  <include package="plone.app.dexterity" file="meta.zcml"/>
+
+  <include package="Products.CMFPlone" />
+  <include package="plone.behavior" />
+  <include package="plone.dexterity" />
+  <include package="plone.namedfile" />
+  <include package="plone.app.contentmenu" />
+  <include package="plone.app.dexterity" />
   <include package="plone.app.event" />
+  <include package="plone.app.linkintegrity" />
+  <include package="plone.app.lockingbehavior" />
+  <include package="plone.app.querystring" />
+  <include package="plone.app.relationfield" />
+  <include package="plone.app.versioningbehavior" />
+  <include package="plone.app.z3cform" />
+
   <include file="profiles.zcml" />
 
   <include package=".behaviors" />


### PR DESCRIPTION
This is instead of using includeDependencies.

See https://github.com/plone/Products.CMFPlone/issues/2952