### PR TITLE
Migration tests, uninstalls plone.app.contentypes if previously installed.

### DIFF
--- a/news/535.bugfix
+++ b/news/535.bugfix
@@ -1,0 +1,2 @@
+for migration tests uninstall plone.app.contenttypes if previously installed
+[ericof]

--- a/plone/app/contenttypes/testing.py
+++ b/plone/app/contenttypes/testing.py
@@ -12,6 +12,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.testing import z2
+from Products.CMFPlone.utils import get_installer
 from zope.interface import alsoProvides
 
 import pkg_resources
@@ -107,6 +108,11 @@ class PloneAppContenttypesMigration(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         if not TEST_MIGRATION:
             return
+
+        # Uninstall plone.app.contenttypes if already installed
+        qi = get_installer(portal)
+        if qi.is_product_installed('plone.app.contenttypes'):
+            qi.uninstall_product('plone.app.contenttypes')
 
         # install Products.ATContentTypes manually if profile is available
         # (this is only needed for Plone >= 5)


### PR DESCRIPTION
If Products.ATContentTypes is available and plone.app.contenttypes is installed by the addPloneSite method, migration tests will fail.

To solve this, we first uninstalll plone.app.contenttypes durint test setup.

This is a blocker for another [pull request](https://github.com/plone/Products.CMFPlone/pull/2971) on CMFPlone.
