### PR TITLE
Fix richtext getText view to use the correct schema interface.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Changelog
 Bug fixes:
 
 
+- Fix richtext ``getText`` view to use the correct schema interface.
+  [thet]
+
 - Robot tests: split big content listing scenario, fix deprecations.
   [maurits] (#533)
 

--- a/plone/app/contenttypes/behaviors/richtext.py
+++ b/plone/app/contenttypes/behaviors/richtext.py
@@ -46,4 +46,4 @@ class RichText(object):
 
 
 class WidgetView(WidgetsView):
-    schema = IRichText
+    schema = IRichTextBehavior


### PR DESCRIPTION
@datakurre since version 2.0 the behavior names were renamed. The ``getText`` view for richtext was forgotten. There are not tests and it is not used in plone.app.contenttypes.  From your commit messages ([1], [2]) it looks like "BBB" code.

Should we merge my fix or remove the code?

[1] https://github.com/plone/plone.app.contenttypes/commit/9c40ed0c8ac3b55c62c0422094e188c1dbcfe5cc#diff-c53d5bba65836ce2021029c7829028da
[2] https://github.com/plone/plone.app.contenttypes/commit/62bf3b8d03310889260c07517cbfd06162cd0c99#diff-2f5868c3a427009d74372bcf983693ee
