### PR TITLE
No text attribute

### DIFF
--- a/news/1.bugfix
+++ b/news/1.bugfix
@@ -1,0 +1,3 @@
+A content type with the richtext behavior might not have a `text` attribute,
+handle that gracefully.
+[gforcada]

--- a/plone/app/contenttypes/behaviors/richtext.py
+++ b/plone/app/contenttypes/behaviors/richtext.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_base
 from plone.app.contenttypes import _
 from plone.app.textfield import RichText as RichTextField
 from plone.app.z3cform.widget import RichTextFieldWidget
@@ -38,7 +39,7 @@ class RichText(object):
 
     @property
     def text(self):
-        return self.context.text
+        return getattr(aq_base(self.context), 'text', '')
 
     @text.setter
     def text(self, value):


### PR DESCRIPTION
If a content type has the richtext behavior enabled, but the text field is not mandatory, plone.app.linkintegrity `modifiedContent` event handler will be called and although there (on p.a.linkintegrity) there is already a `getattr`, here in p.a.contenttypes we try to access the attribute without first checking if it exists at all.

This PR tries to handle that.