### PR TITLE
Add a guard in the document.pt template to allow the Document type no…

### DIFF
--- a/news/3047.bugfix
+++ b/news/3047.bugfix
@@ -1,0 +1,3 @@
+Add a guard in the document.pt template to allow the Document type not to have the RichText
+enforce the behavior enabled.
+[sneridagh]

--- a/plone/app/contenttypes/browser/templates/document.pt
+++ b/plone/app/contenttypes/browser/templates/document.pt
@@ -11,7 +11,7 @@
 <metal:content-core define-macro="content-core"
                     tal:define="toc context/table_of_contents|nothing;">
   <div id="parent-fieldname-text"
-      tal:condition="context/text"
+      tal:condition="context/text | nothing"
       tal:content="structure python:context.text.output_relative_to(view.context)"
       tal:attributes="class python: toc and 'pat-autotoc' or ''" />
 </metal:content-core>


### PR DESCRIPTION
…t to have the RichText enforce the behavior enabled.