### PR TITLE
Improve _replace_variable_by_path

### DIFF
--- a/plone/app/contenttypes/utils.py
+++ b/plone/app/contenttypes/utils.py
@@ -40,5 +40,5 @@ def replace_link_variables_by_paths(context, url):
 
 
 def _replace_variable_by_path(url, variable, obj):
-    path = '/'.join(obj.getPhysicalPath())
+    path = obj.absolute_url()
     return url.replace(variable, path)


### PR DESCRIPTION
Return an url and not a path

At this moment we use `"/".join(obj.getPhysicalPath()`) to replace
${navigation_root_url} and ${portal_url} in Link redirection indexer but with
production site (with reverse proxy), it seems use acquisition to get correct link.

Example for same portal in production and in development:

**production**
https://mysite.com/my-folder/my-link
with remoteUrl = ${navigation_root_url}/my-other-folder

**devl**
http://localhost:8080/plone/my-folder/my-link
with same remoteUrl

generated link in dev is good (http://localhost:8080/plone/my-other-folder/)
but in production, it's not correct, indeed it's
`https://mysite.com/plone/my-other-folder/ `
and it should be
`https://mysite.com/my-other-folder/`

'plone' path should not be in the link.
It maybe works with acquisition, but it's not correct .
So I simply replace '/'.join(obj.getPhysicalPath()) by
obj.absolute_url()

Is there good reason to use getPhysicalPath instead of absolute_url?

Here is how to reproduce with docker-compose.yml file and a reverse proxy :

```
version: '3'
services:
  zeo:
    image: plone:5.2.1-alpine
    command: zeo
  instance:
    image: plone:5.2.1-alpine
    ports:
      - 8080:8080
    environment:
      - ZEO_ADDRESS=zeo:8080
    links:
      - zeo
    depends_on:
      - reverseproxy
    labels:
      - 'traefik.enable=true'
      - 'traefik.http.routers.instance.rule=Host(`portal.localhost`)'
      - 'traefik.http.routers.instance.entrypoints=web'
      - 'traefik.http.services.instance.loadbalancer.server.port=8080'
      - "traefik.http.routers.instance.middlewares=add-plone"
      - "traefik.http.middlewares.add-plone.addprefix.prefix=/VirtualHostBase/http/portal.localhost/plone/VirtualHostRoot"

  reverseproxy:
    image: traefik
    command:
      - '--api.insecure=true'
      - '--providers.docker=true'
      - '--entryPoints.web.address=:80'
    ports:
      - '80:80' # The HTTP port
      - '8000:8080' # The Web UI (enabled by --api)
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
```
- start plone with docker-compose up
- Go to http://localhost:8080
- Add plone site with id "plone"
- Create a link to internal page (example: front-page)
- Go to http://portal.localhost and click on your new link on menu bar

then you have

```
We’re sorry, but there seems to be an error…

If you are certain you have the correct web address but are encountering an error, please contact the site administration.
```
