### PR TITLE
Avoid doing the search twice in listings by reusing the batch variable (Plone 4.3)

### DIFF
--- a/news/560.bugfix
+++ b/news/560.bugfix
@@ -1,0 +1,2 @@
+Avoid doing the search twice in listings by reusing the batch variable.
+[vincentfretin]

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -112,7 +112,7 @@
 
       <metal:empty metal:define-slot="no_items_in_listing">
         <p class="discreet"
-            tal:condition="not: view/batch"
+            tal:condition="not: batch"
             tal:content="view/no_items_message">
           There are currently no items in this folder.
         </p>

--- a/plone/app/contenttypes/browser/templates/listing_tabular.pt
+++ b/plone/app/contenttypes/browser/templates/listing_tabular.pt
@@ -85,7 +85,7 @@
 
     <metal:empty metal:define-slot="no_items_in_listing">
     <p class="discreet"
-    tal:condition="not: view/batch"
+    tal:condition="not: batch"
     tal:content="view/no_items_message">
     There are currently no items in this folder.
     </p>


### PR DESCRIPTION
This fixes https://github.com/plone/plone.app.contenttypes/issues/560