### PR TITLE
Fixed problems in getMimeTypeIcon.

### DIFF
--- a/news/569.bugfix
+++ b/news/569.bugfix
@@ -1,0 +1,3 @@
+Fixed problems in ``getMimeTypeIcon``.
+The contentType of the file was ignored, and icon paths could have a duplicate ``++resource++mimetype.icons/``.
+[maurits]

--- a/plone/app/contenttypes/browser/utils.py
+++ b/plone/app/contenttypes/browser/utils.py
@@ -9,6 +9,9 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 
+PREFIX = "++resource++mimetype.icons/"
+
+
 class IUtils(Interface):
     """
     """
@@ -21,43 +24,39 @@ class IUtils(Interface):
 
 @implementer(IUtils)
 class Utils(BrowserView):
+    def _get_mimes(self, content_file):
+        # We use 'yield' so iteration can be cut short
+        # if the calling code is happy.
+        context = aq_inner(self.context)
+        mtr = getToolByName(context, "mimetypes_registry")
+        if content_file.contentType:
+            # this gives a tuple
+            for mime in mtr.lookup(content_file.contentType):
+                yield mime
+        if content_file.filename:
+            # this gives a single mime type
+            yield mtr.lookupExtension(content_file.filename)
+        for mime in mtr.lookup("application/octet-stream"):
+            yield mime
 
     @memoize
     def getMimeTypeIcon(self, content_file):
+        # Get possible mime types, and try to find an icon path.
+        # Keep the first one, in case there is no good match.
+        first = None
+        for mime in self._get_mimes(content_file):
+            if first is None:
+                first = mime
+            if hasattr(mime, "icon_path"):
+                icon_path = mime.icon_path
+                if not icon_path.startswith("++"):
+                    icon_path = PREFIX + icon_path
+                return icon_path
+
+        if first is None:
+            # Probably does not happen in practice.
+            return ""
         context = aq_inner(self.context)
-        pstate = getMultiAdapter(
-            (context, self.request),
-            name=u'plone_portal_state'
-        )
+        pstate = getMultiAdapter((context, self.request), name=u"plone_portal_state")
         portal_url = pstate.portal_url()
-        mtr = getToolByName(context, 'mimetypes_registry')
-        mime = []
-        if content_file.contentType:
-            mime.append(mtr.lookup(content_file.contentType))
-        if content_file.filename:
-            mime.append(mtr.lookupExtension(content_file.filename))
-        mime.append(mtr.lookup('application/octet-stream')[0])
-        icon_paths = ['++resource++mimetype.icons/' + m.icon_path
-                      for m in mime if hasattr(m, 'icon_path')]
-        if icon_paths:
-            return icon_paths[0]
-
-        return portal_url + '/' + guess_icon_path(mime[0])
-
-        # function works but is possibly not best implementation. following
-        # code might work for files where the mimetype is not directly
-        # recognized
-
-#        if len(mime) > 0:
-#            icon = portal_url + "/" + guess_icon_path(mime[0])
-#        else:
-#            mime = mtr.lookupExtension(content_file.filename)
-#            if mime <> "":
-#                icon = portal_url + "/" + guess_icon_path(mime)
-#            else:
-#                logger.info(
-#                   "No MimeType Icon found for MimeType: " + \
-#                   str(content_file.contentType)
-#                   )
-#                icon = portal_url + "/application.png"
-#        return icon
+        return portal_url + "/" + guess_icon_path(first)

--- a/plone/app/contenttypes/tests/test_browser_utils.py
+++ b/plone/app/contenttypes/tests/test_browser_utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from plone.app.contenttypes.testing import (
+    PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING,
+)  # noqa
+from zope.component import getMultiAdapter
+
+import unittest
+
+
+# The default fallback is the icon for 'application/octet-stream':
+FALLBACK = "++resource++mimetype.icons/application.png"
+# Most or all icons should have this as prefix:
+PREFIX = "++resource++mimetype.icons/"
+
+
+class DummyFile(object):
+    """Dummy file object.
+
+    For these tests, we only need a contentType and filename.
+    """
+
+    def __init__(self, contentType, filename):
+        self.contentType = contentType
+        self.filename = filename
+
+
+class MimeTypeIconIntegrationTest(unittest.TestCase):
+
+    layer = PLONE_APP_CONTENTTYPES_INTEGRATION_TESTING
+
+    def setUp(self):
+        portal = self.layer["portal"]
+        request = self.layer["request"]
+        self.view = getMultiAdapter((portal, request), name="contenttype_utils")
+
+    def test_none(self):
+        self.assertEqual(self.view.getMimeTypeIcon(DummyFile(None, None)), FALLBACK)
+
+    def test_unknown(self):
+        self.assertEqual(
+            self.view.getMimeTypeIcon(DummyFile("some/unknown", "unkown.unknown")),
+            FALLBACK,
+        )
+
+    def test_contenttype_pdf(self):
+        self.assertEqual(
+            self.view.getMimeTypeIcon(DummyFile("application/pdf", None)),
+            PREFIX + "pdf.png",
+        )
+
+    def test_filename_pdf(self):
+        self.assertEqual(
+            self.view.getMimeTypeIcon(DummyFile(None, "plone.pdf")), PREFIX + "pdf.png"
+        )


### PR DESCRIPTION
The contentType of the file was ignored, and icon paths could have a duplicate `++resource++mimetype.icons/`.
Fixes issue #569.

Added tests for the method, using dummy files.
Note that in `test_file.py` there already are indirect tests with real files, checking that a specific [icon is on the rendered page](https://github.com/plone/plone.app.contenttypes/blob/2.1.9/plone/app/contenttypes/tests/test_file.py#L171).