### PR TITLE
Catch AttributeError for getNextPreviousEnabled during migration.

### DIFF
--- a/news/582.bugfix
+++ b/news/582.bugfix
@@ -1,0 +1,2 @@
+Catch AttributeError for ``getNextPreviousEnabled`` during migration.
+[maurits]

--- a/plone/app/contenttypes/migration/migration.py
+++ b/plone/app/contenttypes/migration/migration.py
@@ -188,9 +188,14 @@ class ATCTFolderMigrator(CMFFolderMigrator):
         migrate_leadimage(self.old, self.new)
 
     def migrate_nextprevious(self):
-        if self.old.getNextPreviousEnabled():
-            if INextPreviousToggle.providedBy(self.new):
-                self.new.nextPreviousEnabled = True
+        try:
+            enabled = self.old.getNextPreviousEnabled()
+        except AttributeError:
+            # The old type may not have this.
+            # https://github.com/plone/plone.app.contenttypes/issues/582
+            return
+        if enabled and INextPreviousToggle.providedBy(self.new):
+            self.new.nextPreviousEnabled = True
 
     def last_migrate_comments(self):
         """Migrate the plone.app.discussion comments.


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.contenttypes/issues/582
Sample error:

```
2021-01-11 21:30:37,748 ERROR   [ATCT.migration:205][waitress-0] Failed migration for object /minaraad/digibib/meetings/20130507-0 (Meeting -> Meeting)
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp27m/Products.contentmigration-2.2.1-py2.7.egg/Products/contentmigration/basemigrator/walker.py", line 194, in migrate
    migrator.migrate()
  File "/Users/maurits/shared-eggs/cp27m/Products.contentmigration-2.2.1-py2.7.egg/Products/contentmigration/basemigrator/migrator.py", line 220, in migrate
    method()
  File "/Users/maurits/shared-eggs/cp27m/plone.app.contenttypes-2.2.1-py2.7.egg/plone/app/contenttypes/migration/migration.py", line 191, in migrate_nextprevious
    if self.old.getNextPreviousEnabled():
AttributeError: 'RequestContainer' object has no attribute 'getNextPreviousEnabled'
```