### PR TITLE
Hide the upgrade profile.

### DIFF
--- a/plone/app/contenttypes/setuphandlers.py
+++ b/plone/app/contenttypes/setuphandlers.py
@@ -39,6 +39,7 @@ class HiddenProfiles(object):
         return [
             u'plone.app.contenttypes:uninstall',
             u'plone.app.contenttypes:default',
+            u'plone.app.contenttypes:1007',
         ]
 
 


### PR DESCRIPTION
An upgrade profile was added in PR #590 but was not hidden.
This causes a test in `Products/CMFPlone/controlpanel/tests/test_controlpanel_browser_installer.py` to [fail](https://jenkins.plone.org/job/plone-6.0-python-3.6/226/testReport/junit/Products.CMFPlone.controlpanel.tests.test_controlpanel_browser_installer/AddonsControlPanelFunctionalTest/test_addons_controlpanel_install_and_uninstall_all/).
In `test_addons_controlpanel_install_and_uninstall_all` we unexpectedly find an Uninstall button.

This can be seen when you create a fresh site.  In the Modules control panel you can uninstall plone.app.contenttypes.
Things go rather wrong when you try that. :-)