### PR TITLE
Fix space in custom migration

### DIFF
--- a/news/305.bugfix
+++ b/news/305.bugfix
@@ -1,0 +1,6 @@
+in custom_migration.migrate the form_dx_typename should contain _space_  to match the dx_key
+
+the getDXFields javascript function doesn't replace all space in at_typename,
+causing forms to non load right fields list, or not load it at all.
+
+[gianniftp]

--- a/plone/app/contenttypes/migration/custom_migration.pt
+++ b/plone/app/contenttypes/migration/custom_migration.pt
@@ -41,7 +41,7 @@
     <script type="text/javascript">
         // function that toggle an icon by calling the p_viewName view
         function getDXFields(at_typename, dx_typename) {
-          at_safe = at_typename.replace(' ', '_space_');
+          at_safe = at_typename.replaceAll(' ', '_space_');
           $.ajax({
             url: '@@display_dx_fields',
             dataType: 'html',

--- a/plone/app/contenttypes/migration/custom_migration.py
+++ b/plone/app/contenttypes/migration/custom_migration.py
@@ -63,7 +63,8 @@ class CustomMigrationForm(BrowserView):
                     raw_message = 'Migration applied successfully for {0} ' \
                         '"{1}" items.'
                     msg = translate(
-                        raw_message.format(res_infos.get('counter'), res_type),
+                        raw_message.format(
+                            res_infos.get('counter'), res_type),
                         domain='plone.app.contenttypes',
                     )
                     messages.add(msg, type=u'info')
@@ -165,14 +166,15 @@ class CustomMigrationForm(BrowserView):
             return results
         for field in schema.fields():
             if not field.getName() in self.at_metadata_fields:
-                translated_label = translate(safe_unicode(field.widget.label))
+                translated_label = translate(
+                    safe_unicode(field.widget.label))
                 results.append(
                     {'id': field.getName(),
                      'title': '{0} ({1})'.format(
                          translated_label,
                          field.getType()
-                     ),
-                     'type': field.getType()}
+                    ),
+                        'type': field.getType()}
                 )
         return results
 
@@ -199,8 +201,8 @@ class CustomMigrationForm(BrowserView):
                      'title': '{0} ({1})'.format(
                          translated_label,
                          field.getType()
-                     ),
-                     'type': field.getType()}
+                    ),
+                        'type': field.getType()}
                 )
         return results
 
@@ -257,6 +259,8 @@ class CustomMigrationForm(BrowserView):
                 form_dx_typename = form[k]
                 at_typename = form_at_typename.replace('_space_', ' ')
                 dx_typename = form_dx_typename.replace('_space_', ' ')
+                # the form_dx_typename should contain _space_  to match the dx_key
+                form_dx_typename.replace(' ', '_space_')
 
                 data[at_typename] = {'target_type': dx_typename,
                                      'field_mapping': []}
@@ -296,7 +300,7 @@ class CustomMigrationForm(BrowserView):
                 dst_type=data[at_typename]['target_type'],
                 dry_run=dry_run,
                 patch_searchabletext=patch_searchabletext,
-                )
+            )
             migration_results.append({'type': at_typename,
                                       'infos': res})
         return migration_results


### PR DESCRIPTION
on plone 5.0.10 (python 2.7.18) i'm migrating some AT contents. 
Using the @@custom_migration form there is a problem with spaces in at names.
the problem is already known in an issue solved in plone.app.contenttype 1.1.x, but non fixed in next releases (#305).

the fix proposed isn't enough, as also the javascript function that manage the fields listing in the form is faulty in managing spaces in types names. 

this could fix the @@custom_migration form