### PR TITLE
Fix for #486

### DIFF
--- a/news/486.bugfix
+++ b/news/486.bugfix
@@ -1,0 +1,1 @@
+Fix broken summary view when thumbnails are disabled [alecpm]

--- a/plone/app/contenttypes/browser/templates/listing_summary.pt
+++ b/plone/app/contenttypes/browser/templates/listing_summary.pt
@@ -30,8 +30,7 @@
 
           <div metal:use-macro="context/@@listing_view/macros/document_byline"></div>
 
-          <div tal:define="thumb_url python:item_url + '/@@images/image/' + thumb_scale_summary;"
-               tal:condition="python: item_has_image and thumb_scale_summary"
+          <div tal:condition="python: item_has_image and thumb_scale_summary"
                tal:attributes="class python: 'tileImage' if item_description else 'tileImageNoFloat'">
             <a tal:attributes="href item_link">
               <img tal:replace="structure python:image_scale.tag(item, 'image', scale=thumb_scale_summary, css_class='thumb-' + thumb_scale_summary)" />


### PR DESCRIPTION
This fixes a long standing and serious issue with the summary view from v1.4.1 where disabling thumbnails fro the Site control panel would cause it to thow a traceback:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 266, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 58, in __call__
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 214, in render
  Module chameleon.utils, line 53, in raise_with_traceback
  Module chameleon.template, line 192, in render
  Module 21c4cf128bad7545198495d7cb899d31, line 650, in render
  Module 2d1571356263e8cd1c946fe23f300f29, line 860, in render_master
  Module 2d1571356263e8cd1c946fe23f300f29, line 1489, in render_content
  Module 21c4cf128bad7545198495d7cb899d31, line 635, in __fill_content_core
  Module 21c4cf128bad7545198495d7cb899d31, line 387, in render_content_core
  Module 720ac2df5e24b26392deaed5ddf34996, line 122, in render_content_core
  Module 720ac2df5e24b26392deaed5ddf34996, line 505, in render_listing
  Module 21c4cf128bad7545198495d7cb899d31, line 360, in __fill_entries
  Module 720ac2df5e24b26392deaed5ddf34996, line 952, in render_entries
  Module 21c4cf128bad7545198495d7cb899d31, line 196, in __fill_entry
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (item_url + '/@@images/image/' + thumb_scale_summary)
  Module <string>, line 1, in <module>
TypeError: can only concatenate str (not "NoneType") to str
```

I made this PR against the `2.2.x` branch because that's the code I need it for. It should apply cleanly to `1.4.x` and straighforwardly to `master`.