### PR TITLE
Removed autoinclude entry point.

### DIFF
--- a/news/611.bugfix
+++ b/news/611.bugfix
@@ -1,0 +1,3 @@
+Removed autoinclude entry point.
+No longer needed, since ``Products.CMFPlone`` explicitly includes our zcml.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,4 @@ setup(
             "plone.app.referenceablebehavior",
         ],
     },
-    entry_points="""
-      # -*- Entry points: -*-
-      [z3c.autoinclude.plugin]
-      target = plone
-      """,
 )


### PR DESCRIPTION
No longer needed, since `Products.CMFPlone` explicitly includes our zcml.