### PR TITLE
Adapt the tests for Plone 6

### DIFF
--- a/news/616.bugfix
+++ b/news/616.bugfix
@@ -1,0 +1,1 @@
+Adapt the tests to cope with the fact the since Plone 6 the Plone site root is cataloged [ale-rt]

--- a/plone/app/contenttypes/tests/test_indexes.py
+++ b/plone/app/contenttypes/tests/test_indexes.py
@@ -131,6 +131,7 @@ class CatalogIntegrationTest(unittest.TestCase):
         self.link.reindexObject()
         brains = self.catalog.searchResults(dict(
             SearchableText='plone',
+            portal_type='Link',
         ))
         self.assertEqual(len(brains), 1)
         self.assertEqual(


### PR DESCRIPTION
Adapt the tests to cope with the fact the since Plone 6 the Plone site root is cataloged

The following PR should be merged together:

https://github.com/plone/plone.app.content/pull/236
https://github.com/plone/plone.app.contentlisting/pull/39
https://github.com/plone/plone.app.contenttypes/pull/616
https://github.com/plone/plone.app.upgrade/pull/264
https://github.com/plone/plone.restapi/pull/1251
https://github.com/plone/Products.CMFPlone/pull/3343