### PR TITLE
Fix tests with ES6.

### DIFF
--- a/news/6.bugfix
+++ b/news/6.bugfix
@@ -1,0 +1,2 @@
+Fix tests with ES6.
+[maurits]

--- a/plone/app/contenttypes/tests/robot/test_folderlisting.robot
+++ b/plone/app/contenttypes/tests/robot/test_folderlisting.robot
@@ -231,5 +231,7 @@ I go to
 I disable dropdown navigation
   Go to  ${PLONE_URL}/@@navigation-controlpanel
   Input Text  name=form.widgets.navigation_depth  1
+  Set Focus To Element  css=#form-buttons-save
+  Wait Until Element Is Visible  css=#form-buttons-save
   Click Button  Save
   Wait until page contains  Changes saved


### PR DESCRIPTION
In lots of robot tests we are seeing that you need to:

- focus on an element
- wait until it is visible
- only *then* click on it.

Part of PLIP https://github.com/plone/Products.CMFPlone/issues/3211