### PR TITLE
Robot tests: use more specific element when clicking Save button.

### DIFF
--- a/news/3582.bugfix
+++ b/news/3582.bugfix
@@ -1,0 +1,3 @@
+Robot tests: use more specific element when clicking Save button.
+'Click Button Save' sometimes failed.
+[maurits]

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -37,7 +37,7 @@ a file
   Wait until page contains  Add File
   Input text  name=form.widgets.title  ${title}
   Choose File  name=form.widgets.file  ${PATH_TO_TEST_FILES}/file.pdf
-  Click Button  Save
+  Wait For Then Click Element  css=#form-buttons-save
   Wait until page contains  Item created
 
 a folder
@@ -51,7 +51,7 @@ a image
   Wait until page contains  Add Image
   Input text  name=form.widgets.title  ${title}
   Choose File  name=form.widgets.image  ${PATH_TO_TEST_FILES}/image.png
-  Click Button  Save
+  Wait For Then Click Element  css=#form-buttons-save
   Wait until page contains  Item created  error=Image could not be created.
 
 a link
@@ -65,7 +65,7 @@ a news item
   Go to  ${PLONE_URL}/++add++News Item
   Wait until page contains  Add News Item
   Input text  name=form.widgets.IDublinCore.title  ${title}
-  Click Button  Save
+  Wait For Then Click Element  css=#form-buttons-save
   Wait until page contains  Item created
 
 


### PR DESCRIPTION
'Click Button Save' sometimes failed.
See two failures on Jenkins: https://jenkins.plone.org/job/plone-6.0-python-3.9-robot-chrome/1355/robot/