### PR TITLE
run robot tests on gh-actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[report]
-omit =
-    */test*
-
-include =
-    plone/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 /.pydevproject
 /.mr.developer.cfg
 /src/*
+/robot_*
+/test_*
 *.mo
 docs/Makefile
 docs/make.bat

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,4 +2,7 @@
 # https://github.com/plone/meta/tree/master/config/default
 [meta]
 template = "default"
-commit-id = "47959565"
+commit-id = "112d1c69"
+
+[codespell]
+additional-ignores = "discreet,oder,ist,crate"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.0.2
+    rev: 3.0.3
     hooks:
     -   id: zpretty
 -   repo: https://github.com/PyCQA/flake8

--- a/news/69.tests
+++ b/news/69.tests
@@ -1,0 +1,2 @@
+Run the robot tests.
+[maurits]

--- a/plone/app/contenttypes/tests/robot/keywords.txt
+++ b/plone/app/contenttypes/tests/robot/keywords.txt
@@ -2,7 +2,7 @@
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Variables  plone/app/contenttypes/tests/robot/variables.py
+Variables  variables.py
 
 *** Keywords ***
 

--- a/plone/app/contenttypes/tests/robot/test_collection_creator_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_creator_criterion.robot
@@ -13,7 +13,7 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 

--- a/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_location_criterion.robot
@@ -13,9 +13,9 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
-Variables  plone/app/contenttypes/tests/robot/variables.py
+Variables  variables.py
 
 Test Setup  Run Keywords  Plone test setup
 Test Teardown  Run keywords  Plone test teardown

--- a/plone/app/contenttypes/tests/robot/test_collection_review_state_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_review_state_criterion.robot
@@ -13,7 +13,7 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
 Test Setup  Run Keywords  Plone test setup
 Test Teardown  Run keywords  Plone test teardown

--- a/plone/app/contenttypes/tests/robot/test_collection_short_name_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_short_name_criterion.robot
@@ -13,7 +13,7 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
 Test Setup  Run Keywords  Plone test setup
 Test Teardown  Run keywords  Plone test teardown

--- a/plone/app/contenttypes/tests/robot/test_collection_type_criterion.robot
+++ b/plone/app/contenttypes/tests/robot/test_collection_type_criterion.robot
@@ -13,7 +13,7 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
 Test Setup  Run Keywords  Plone test setup
 Test Teardown  Run keywords  Plone test teardown

--- a/plone/app/contenttypes/tests/robot/test_folderlisting.robot
+++ b/plone/app/contenttypes/tests/robot/test_folderlisting.robot
@@ -3,9 +3,9 @@
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
 
-Variables  plone/app/contenttypes/tests/robot/variables.py
+Variables  variables.py
 
 
 Test Setup  Run Keywords  Setup Testcontent  Plone test setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ profile = "plone"
 [tool.black]
 target-version = ["py38"]
 
+[tool.codespell]
+ignore-words-list = "discreet,oder,ist,crate"
+
 [tool.dependencychecker]
 Zope = [
   # Zope own provided namespaces
@@ -60,6 +63,3 @@ Zope = [
   'Products.CMFDynamicViewFTI', 'zope.deprecation',
 ]
 python-dateutil = ['dateutil']
-
-[tool.codespell]
-ignore-words-list = "discreet,oder,ist,crate"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,5 +20,4 @@ ignore =
     .editorconfig
     .meta.toml
     .pre-commit-config.yaml
-    .coveragerc
     tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,6 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    zope-testrunner --test-path={toxinidir} -s plone.app.contenttypes
+    zope-testrunner --all --test-path={toxinidir} -s plone.app.contenttypes {posargs}
 extras =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands =
 [testenv:test]
 usedevelop = true
 constrain_package_deps = true
+set_env = ROBOT_BROWSER=headlesschrome
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt


### PR DESCRIPTION
Uses https://github.com/plone/meta/pull/69

I had to change some resources slightly, otherwise they were not found:

```
-Resource  plone/app/contenttypes/tests/robot/keywords.txt
+Resource  keywords.txt
```

For running the tests from the coredev buildout this makes no difference.

Also: in coredev the tests are run with headless Chrome, and here in the package using `tox -e test` they are run with Firefox in the foreground.  I have `ROBOT_BROWSER=headlesschrome` in my environment variables.  So: a bit strange, no idea what causes this difference, but it works.