### PR TITLE
no brackets for displaying lists or tuples

### DIFF
--- a/plone/app/contenttypes/browser/folder.py
+++ b/plone/app/contenttypes/browser/folder.py
@@ -179,6 +179,10 @@ class FolderView(BrowserView):
         ]:
             value = self.toLocalizedTime(value, long_format=1)
 
+        if isinstance(value, (list, tuple)):
+            value  = ', '.join([entry for entry in value])
+
+
         return {
             # 'title': _(fieldname, default=fieldname),
             "value": value


### PR DESCRIPTION
In the tabular view, it would be cleaner to only display the values, instead of the entire tuple/list object.