### PR TITLE
Fix folder listing template when `plone.eventlocation` behavior is disabled

### DIFF
--- a/news/679.bugfix
+++ b/news/679.bugfix
@@ -1,0 +1,2 @@
+Fix folder listing template when `plone.eventlocation` behavior is disabled for Events.
+[petschki]

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -93,7 +93,7 @@
 
                               <tal:event condition="python:item_is_event">
                                 <tal:date tal:replace="structure python:view.formatted_date(obj)" />
-                                <span tal:condition="python:obj.location if hasattr(obj, 'location') else None"
+                                <span tal:condition="python:getattr(obj.aq_base, 'location', None)"
                                       i18n:translate="label_event_byline_location"
                                 >
                             &mdash;

--- a/plone/app/contenttypes/browser/templates/listing.pt
+++ b/plone/app/contenttypes/browser/templates/listing.pt
@@ -93,7 +93,7 @@
 
                               <tal:event condition="python:item_is_event">
                                 <tal:date tal:replace="structure python:view.formatted_date(obj)" />
-                                <span tal:condition="python:obj.location"
+                                <span tal:condition="python:obj.location if hasattr(obj, 'location') else None"
                                       i18n:translate="label_event_byline_location"
                                 >
                             &mdash;

--- a/plone/app/contenttypes/tests/test_folder.py
+++ b/plone/app/contenttypes/tests/test_folder.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timedelta
 from plone.app.contenttypes.browser.folder import FolderView
 from plone.app.contenttypes.interfaces import IFolder
 from plone.app.contenttypes.testing import (  # noqa
@@ -232,3 +234,26 @@ class FolderViewFunctionalTest(unittest.TestCase):
         # And also in tabular view
         self.browser.open(self.folder_url + "/tabular_view")
         self.assertIn("doc_wout_title", self.browser.contents)
+
+    def test_event_wout_location(self):
+        # deactivate "plone.eventlocation" from Event behaviors
+        event_fti = self.portal.portal_types.get("Event")
+        if not event_fti:
+            return
+        event_behaviors = list(event_fti.behaviors)
+        event_behaviors.remove("plone.eventlocation")
+        event_fti.behaviors = tuple(event_behaviors)
+
+        self.folder.invokeFactory(
+            "Event",
+            id="event_wout_location",
+            title="Event without location",
+            start=datetime.now() + timedelta(days=1),
+        )
+
+        import transaction
+
+        transaction.commit()
+
+        self.browser.open(self.folder_url + "/listing_view")
+        self.assertIn("Event without location", self.browser.contents)


### PR DESCRIPTION
fixes #679 