### PR TITLE
Set exclude_from_nav=True on Members folder

### DIFF
--- a/news/830.bugfix
+++ b/news/830.bugfix
@@ -1,0 +1,3 @@
+Set ``exclude_from_nav=True`` on the Members folder during site creation.
+Previously the Members folder was accidentally hidden from navigation because the ``exclude_from_nav`` index was not populated (due to a site-manager issue during deferred catalog queue processing).
+@jensens

--- a/src/plone/app/contenttypes/setuphandlers.py
+++ b/src/plone/app/contenttypes/setuphandlers.py
@@ -307,6 +307,7 @@ def configure_members_folder(portal, target_language):
         )
         container = addContentToContainer(portal, container)
         container.setOrdering("unordered")
+        container.exclude_from_nav = True
         container.reindexObject()
 
         # set member search as default layout to Members Area


### PR DESCRIPTION
## Summary

- The Members folder was never explicitly excluded from navigation
- Previously hidden by accident: the `exclude_from_nav` indexer silently failed during deferred catalog queue processing (site manager not set at `before_commit` time), leaving the index empty (`None`), which didn't match `exclude_from_nav=False` queries
- With Products.CMFCore 3.9+ and the `_ensure_site` fix (#160), the indexer now works correctly, revealing the missing attribute
- Fix: set `exclude_from_nav=True` explicitly in `configure_members_folder()`

Refs: plone/buildout.coredev#1080, zopefoundation/Products.CMFCore#160

## Test plan

- [x] `TestCatalogPortalTabs::testCreateTopLevelTabs` passes (7 tabs, Members excluded)
- [x] All Catalog navigation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)