### PR TITLE
Restrict title to 1024 when setting it based on a filename. [4.x]

### DIFF
--- a/news/+7b7c8b72.bugfix.rst
+++ b/news/+7b7c8b72.bugfix.rst
@@ -1,0 +1,3 @@
+Restrict title to 1024 and description to 10000.
+This is for images and files.  For others, a similar change is done in ``plone.app.dexterity``.
+[maurits]

--- a/src/plone/app/contenttypes/schema/file.xml
+++ b/src/plone/app/contenttypes/schema/file.xml
@@ -9,6 +9,7 @@
            type="zope.schema.TextLine"
     >
       <description />
+      <max_length>1024</max_length>
       <required>False</required>
       <title i18n:translate="">Title</title>
     </field>
@@ -16,6 +17,7 @@
            type="zope.schema.Text"
     >
       <description />
+      <max_length>10000</max_length>
       <required>False</required>
       <title i18n:translate="">Description</title>
     </field>

--- a/src/plone/app/contenttypes/schema/image.xml
+++ b/src/plone/app/contenttypes/schema/image.xml
@@ -9,6 +9,7 @@
            type="zope.schema.TextLine"
     >
       <description />
+      <max_length>1024</max_length>
       <required>False</required>
       <title i18n:translate="">Title</title>
     </field>
@@ -16,6 +17,7 @@
            type="zope.schema.Text"
     >
       <description />
+      <max_length>10000</max_length>
       <required>False</required>
       <title i18n:translate="">Description</title>
     </field>

--- a/src/plone/app/contenttypes/subscribers.py
+++ b/src/plone/app/contenttypes/subscribers.py
@@ -1,5 +1,10 @@
 from plone.app.contenttypes.interfaces import IImage
 
+try:
+    from plone.app.dexterity.config import MAX_TITLE_LENGTH as _MAX_TITLE_LENGTH
+except ImportError:
+    _MAX_TITLE_LENGTH = 1024
+
 
 def set_title_description(obj, event):
     """Sets title to filename if no title
@@ -14,8 +19,8 @@ def set_title_description(obj, event):
         else:
             datafield = obj.file
         if datafield:
-            filename = datafield.filename
-            obj.title = filename
+            filename = datafield.filename or ""
+            obj.title = filename[:_MAX_TITLE_LENGTH]
 
     description = obj.description
     if not description:

--- a/src/plone/app/contenttypes/tests/test_file.py
+++ b/src/plone/app/contenttypes/tests/test_file.py
@@ -148,6 +148,48 @@ class FileFunctionalTest(unittest.TestCase):
         self.browser.getControl("Save").click()
         self.assertTrue(self.browser.url.endswith("my-special-file/view"))
 
+    def test_long_filename(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("File").click()
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.file")
+        filename = "i" * 2000 + ".png"
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", filename)
+        self.browser.getControl("Save").click()
+        # Something, likely Zope, already restricts the id to 255 characters,
+        # although this does not count the ".png" suffix.
+        content_id = "i" * 255 + ".png"
+        self.assertTrue(self.browser.url.endswith(f"{content_id}/view"))
+        content = self.portal[content_id]
+        self.assertTrue(content.Title(), filename[:1024])
+
+    def test_long_title(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("File").click()
+        widget = "form.widgets.description"
+        self.browser.getControl(name=widget).value = "L" * 10001
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.file")
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", "image.jpg")
+        self.browser.getControl("Save").click()
+        self.assertTrue("There were some errors." in self.browser.contents)
+        self.assertTrue("Value is too long" in self.browser.contents)
+
+    def test_long_description(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("File").click()
+        widget = "form.widgets.title"
+        self.browser.getControl(name=widget).value = "L" * 1025
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.file")
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", "image.jpg")
+        self.browser.getControl("Save").click()
+        self.assertTrue("There were some errors." in self.browser.contents)
+        self.assertTrue("Value is too long" in self.browser.contents)
+
     def test_mime_icon_pdf_for_file_(self):
         self.browser.open(self.portal_url)
         self.browser.getLink("File").click()

--- a/src/plone/app/contenttypes/tests/test_image.py
+++ b/src/plone/app/contenttypes/tests/test_image.py
@@ -157,6 +157,48 @@ class ImageFunctionalTest(unittest.TestCase):
         self.browser.getControl("Save").click()
         self.assertTrue(self.browser.url.endswith("my-special-image.jpg/view"))
 
+    def test_long_filename(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("Image").click()
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.image")
+        filename = "i" * 2000 + ".png"
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", filename)
+        self.browser.getControl("Save").click()
+        # Something, likely Zope, already restricts the id to 255 characters,
+        # although this does not count the ".png" suffix.
+        content_id = "i" * 255 + ".png"
+        self.assertTrue(self.browser.url.endswith(f"{content_id}/view"))
+        content = self.portal[content_id]
+        self.assertTrue(content.Title(), filename[:1024])
+
+    def test_long_title(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("Image").click()
+        widget = "form.widgets.description"
+        self.browser.getControl(name=widget).value = "L" * 10001
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.image")
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", "image.jpg")
+        self.browser.getControl("Save").click()
+        self.assertTrue("There were some errors." in self.browser.contents)
+        self.assertTrue("Value is too long" in self.browser.contents)
+
+    def test_long_description(self):
+        self.browser.open(self.portal_url)
+        self.browser.getLink("Image").click()
+        widget = "form.widgets.title"
+        self.browser.getControl(name=widget).value = "L" * 1025
+        file_path = os.path.join(os.path.dirname(__file__), "image.jpg")
+        file_ctl = self.browser.getControl(name="form.widgets.image")
+        with io.FileIO(file_path, "rb") as f:
+            file_ctl.add_file(f, "image/png", "image.jpg")
+        self.browser.getControl("Save").click()
+        self.assertTrue("There were some errors." in self.browser.contents)
+        self.assertTrue("Value is too long" in self.browser.contents)
+
     def test_image_view_fullscreen(self):
         self.browser.open(self.portal_url)
         self.browser.getLink("Image").click()


### PR DESCRIPTION
Set `max_length` in image and file content types.
Max 1024 for title, max 10000 for description.

For the other types (using `IBasic`), this is being changed in `plone.app.dexterity`.

Backport of https://github.com/plone/plone.app.contenttypes/pull/744 for Plone 6.1.

